### PR TITLE
Add transit wrapper address & token configuration from env

### DIFF
--- a/wrappers/transit/transit_client.go
+++ b/wrappers/transit/transit_client.go
@@ -24,6 +24,12 @@ const (
 	EnvTransitWrapperKeyName   = "TRANSIT_WRAPPER_KEY_NAME"
 	EnvVaultTransitSealKeyName = "VAULT_TRANSIT_SEAL_KEY_NAME"
 
+	EnvTransitWrapperAddr   = "TRANSIT_WRAPPER_ADDR"
+	EnvVaultTransitSealAddr = "VAULT_TRANSIT_SEAL_ADDR"
+
+	EnvTransitWrapperToken   = "TRANSIT_WRAPPER_TOKEN"
+	EnvVaultTransitSealToken = "VAULT_TRANSIT_SEAL_TOKEN"
+
 	EnvTransitWrapperDisableRenewal   = "TRANSIT_WRAPPER_DISABLE_RENEWAL"
 	EnvVaultTransitSealDisableRenewal = "VAULT_TRANSIT_SEAL_DISABLE_RENEWAL"
 )
@@ -92,9 +98,29 @@ func newTransitClient(logger hclog.Logger, opts *options) (*TransitClient, *wrap
 		namespace = opts.withNamespace
 	}
 
+	var address string
+	switch {
+	case os.Getenv(EnvTransitWrapperAddr) != "" && !opts.Options.WithDisallowEnvVars:
+		address = os.Getenv(EnvTransitWrapperAddr)
+	case os.Getenv(EnvVaultTransitSealAddr) != "" && !opts.Options.WithDisallowEnvVars:
+		address = os.Getenv(EnvVaultTransitSealAddr)
+	case opts.withAddress != "":
+		address = opts.withAddress
+	}
+
+	var token string
+	switch {
+	case os.Getenv(EnvTransitWrapperToken) != "" && !opts.Options.WithDisallowEnvVars:
+		token = os.Getenv(EnvTransitWrapperToken)
+	case os.Getenv(EnvVaultTransitSealToken) != "" && !opts.Options.WithDisallowEnvVars:
+		token = os.Getenv(EnvVaultTransitSealToken)
+	case opts.withToken != "":
+		token = opts.withToken
+	}
+
 	apiConfig := api.DefaultConfig()
-	if opts.withAddress != "" {
-		apiConfig.Address = opts.withAddress
+	if address != "" {
+		apiConfig.Address = address
 	}
 	if opts.withTlsCaCert != "" ||
 		opts.withTlsCaPath != "" ||
@@ -120,8 +146,8 @@ func newTransitClient(logger hclog.Logger, opts *options) (*TransitClient, *wrap
 	if err != nil {
 		return nil, nil, err
 	}
-	if opts.withToken != "" {
-		apiClient.SetToken(opts.withToken)
+	if token != "" {
+		apiClient.SetToken(token)
 	}
 	if namespace != "" {
 		apiClient.SetNamespace(namespace)

--- a/wrappers/transit/transit_test.go
+++ b/wrappers/transit/transit_test.go
@@ -312,6 +312,22 @@ func TestSetConfig(t *testing.T) {
 				WithKeyIdPrefix("test/"),
 			},
 		},
+		{
+			name: "success-without-opts",
+			setup: func(t *testing.T) {
+				require.NoError(t, os.Setenv(EnvTransitWrapperAddr, testWithAddress))
+				require.NoError(t, os.Setenv(EnvTransitWrapperToken, testWithToken))
+				require.NoError(t, os.Setenv(EnvTransitWrapperDisableRenewal, testWithDisableRenewal))
+				require.NoError(t, os.Setenv(EnvTransitWrapperKeyName, testWithKeyName))
+				require.NoError(t, os.Setenv(EnvTransitWrapperMountPath, testWithMountPath))
+				t.Cleanup(func() { os.Unsetenv(EnvTransitWrapperAddr) })
+				t.Cleanup(func() { os.Unsetenv(EnvTransitWrapperToken) })
+				t.Cleanup(func() { os.Unsetenv(EnvTransitWrapperDisableRenewal) })
+				t.Cleanup(func() { os.Unsetenv(EnvTransitWrapperKeyName) })
+				t.Cleanup(func() { os.Unsetenv(EnvTransitWrapperMountPath) })
+			},
+			opts: []wrapping.Option{},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Currently, the seal transit can be [configured using several environment variables](https://openbao.org/docs/configuration/seal/transit/), such as `VAULT_TRANSIT_SEAL_KEY_NAME` which already exists before this PR.

However, the address of the root openbao instance & the unseal token generated from said instance can either be set through the hcl configuration, or through the `BAO|VAULT_ADDR` & `BAO|VAULT_TOKEN` variables.

This is an issue as:
- [the `BAO_ADDR` variable is hard-coded in the helm chart](https://github.com/openbao/openbao-helm/blob/main/charts/openbao/templates/server-statefulset.yaml#L102) so it isn't possible to configure the address through env var
- setting `BAO_ADDR` and the `BAO_TOKEN` to values refering to a bao instance outside the running instance' cluster messes up with the usage of the bao CLI. (example: setting `BAO_TOKEN` is something done by `bao login`, which isn't related at all with the unseal)

This PR aims to introduce 2 environment variables, `VAULT_TRANSIT_SEAL_ADDR` & `VAULT_TRANSIT_SEAL_TOKEN` dedicated to the transit seal configuration to prevent conflict with.