### PR TITLE
chore: bump actions/cache to v3.4.3

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
       - name: go mod package cache
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # v3.4.3
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ matrix.go }}-${{ hashFiles('tests/go.mod') }}


### PR DESCRIPTION
According to [this annoucement](https://github.com/actions/cache/discussions/1510) 
> If you are using pinned SHAs, please use the SHAs of versions v4.2.0 or v3.4.0

So i propose to update to v3.4.3 which is the latest v3.4.X release. I could have bumped it to v4 but I'm not sure what the breaking changes are between v3 and v4

See https://github.com/actions/cache/releases/tag/v3.4.3 

Hope this fixes the build for #22 
 
Closes #23