### PR TITLE
transit, pkcs11: implement InitFinalizer correctly

### DIFF
--- a/wrappers/pkcs11/pkcs11.go
+++ b/wrappers/pkcs11/pkcs11.go
@@ -18,8 +18,11 @@ type Wrapper struct {
 	currentKeyId *atomic.Value
 }
 
-// Ensure that we are implementing Wrapper
-var _ wrapping.Wrapper = (*Wrapper)(nil)
+var (
+	// Ensure that we implement both Wrapper and InitFinalizer correctly
+	_ wrapping.Wrapper       = (*Wrapper)(nil)
+	_ wrapping.InitFinalizer = (*Wrapper)(nil)
+)
 
 // NewWrapper creates a new PKCS11 Wrapper
 func NewWrapper() *Wrapper {
@@ -31,12 +34,12 @@ func NewWrapper() *Wrapper {
 }
 
 // Init is called during core.Initialize
-func (k *Wrapper) Init(_ context.Context) error {
+func (k *Wrapper) Init(_ context.Context, _ ...wrapping.Option) error {
 	return nil
 }
 
 // Finalize is called during shutdown
-func (k *Wrapper) Finalize(_ context.Context) error {
+func (k *Wrapper) Finalize(_ context.Context, _ ...wrapping.Option) error {
 	k.client.Close()
 	return nil
 }

--- a/wrappers/transit/transit.go
+++ b/wrappers/transit/transit.go
@@ -22,7 +22,11 @@ type Wrapper struct {
 	keyIdPrefix  string
 }
 
-var _ wrapping.Wrapper = (*Wrapper)(nil)
+var (
+	// Ensure that we implement both Wrapper and InitFinalizer correctly
+	_ wrapping.Wrapper       = (*Wrapper)(nil)
+	_ wrapping.InitFinalizer = (*Wrapper)(nil)
+)
 
 // NewWrapper creates a new transit wrapper
 func NewWrapper() *Wrapper {
@@ -59,12 +63,12 @@ func (s *Wrapper) SetConfig(_ context.Context, opt ...wrapping.Option) (*wrappin
 }
 
 // Init is called during core.Initialize
-func (s *Wrapper) Init(_ context.Context) error {
+func (s *Wrapper) Init(_ context.Context, _ ...wrapping.Option) error {
 	return nil
 }
 
 // Finalize is called during shutdown
-func (s *Wrapper) Finalize(_ context.Context) error {
+func (s *Wrapper) Finalize(_ context.Context, _ ...wrapping.Option) error {
 	s.client.Close()
 	return nil
 }


### PR DESCRIPTION
While playing around with the PKCS#11 wrapper implementation here with respect to https://github.com/openbao/openbao/pull/1320, I noticed that the implementations for `InitFinalizer` in the PKCS#11 and transit wrappers don't have the correct signature. Thus OpenBao never actually calls `Init()` or `Finalize()` because type-asserting to `InitFinalizer` fails.