### PR TITLE
Add provider-specific constant ranges

### DIFF
--- a/kms/cipher.go
+++ b/kms/cipher.go
@@ -37,6 +37,9 @@ type CipherAlgorithm int
 const (
 	CipherAlgo_AES CipherAlgorithm = iota + 1
 	CipherAlgo_RSA
+
+	CipherAlgo_Provider_Specific_Base CipherAlgorithm = 65536
+	CipherAlgo_Provider_Specific_Top  CipherAlgorithm = 165536
 )
 
 func (c CipherAlgorithm) String() string {
@@ -65,6 +68,9 @@ const (
 	CipherMode_RSA_OAEP_SHA256
 	CipherMode_RSA_OAEP_SHA384
 	CipherMode_RSA_OAEP_SHA512
+
+	CipherMode_Provider_Specific_Base CipherAlgorithmMode = 65536
+	CipherMode_Provider_Specific_Top  CipherAlgorithmMode = 165536
 )
 
 func (c CipherAlgorithmMode) String() string {

--- a/kms/key.go
+++ b/kms/key.go
@@ -26,6 +26,9 @@ const (
 	KeyType_EC_Private
 	KeyType_ED_Public
 	KeyType_ED_Private
+
+	KeyType_Provider_Specific_Base KeyType = 65536
+	KeyType_Provider_Specific_Top  KeyType = 165536
 )
 
 func (k KeyType) String() string {
@@ -64,6 +67,9 @@ const (
 	Curve_P256
 	Curve_P384
 	Curve_P521
+
+	Curve_Provider_Specific_Base Curve = 65536
+	Curve_Provider_Specific_Top  Curve = 165536
 )
 
 func (c Curve) String() string {

--- a/kms/signer.go
+++ b/kms/signer.go
@@ -30,6 +30,9 @@ const (
 	SignAlgo_EC_P384
 	SignAlgo_EC_P521
 	SignAlgo_ED
+
+	SignAlgo_Provider_Specific_Base SignAlgorithm = 65536
+	SignAlgo_Provider_Specific_Top  SignAlgorithm = 165536
 )
 
 func (s SignAlgorithm) String() string {


### PR DESCRIPTION
This will allow us to implement compatibility with Wrapper for GCP KMS which currently uses a custom algorithm.