### PR TITLE
Remove ShamirWrapper

### DIFF
--- a/aead/aead.go
+++ b/aead/aead.go
@@ -24,31 +24,15 @@ type Wrapper struct {
 	aead     cipher.AEAD
 }
 
-// ShamirWrapper is here for backwards compatibility for Vault; it reports a
-// type of "shamir" instead of "aead"
-type ShamirWrapper struct {
-	*Wrapper
-}
-
 // Ensure that we are implementing Wrapper
 var (
 	_ wrapping.Wrapper     = (*Wrapper)(nil)
-	_ wrapping.Wrapper     = (*ShamirWrapper)(nil)
 	_ wrapping.KeyExporter = (*Wrapper)(nil)
 )
 
 // NewWrapper creates a new Wrapper. No options are supported.
 func NewWrapper() *Wrapper {
 	return new(Wrapper)
-}
-
-// Deprecated: NewShamirWrapper returns a type of "shamir" instead of "aead" and
-// is for backwards compatibility with old versions of Vault. Do not use in new
-// code.
-func NewShamirWrapper() *ShamirWrapper {
-	return &ShamirWrapper{
-		Wrapper: NewWrapper(),
-	}
 }
 
 // NewDerivedWrapper returns an aead.Wrapper whose key is set to an hkdf-based
@@ -196,10 +180,6 @@ func (s *Wrapper) SetAesGcmKeyBytes(key []byte) error {
 // Type returns the seal type for this particular Wrapper implementation
 func (s *Wrapper) Type(_ context.Context) (wrapping.WrapperType, error) {
 	return wrapping.WrapperTypeAead, nil
-}
-
-func (s *ShamirWrapper) Type(_ context.Context) (wrapping.WrapperType, error) {
-	return wrapping.WrapperTypeShamir, nil
 }
 
 // KeyId returns the last known key id

--- a/aead/aead_test.go
+++ b/aead/aead_test.go
@@ -13,19 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestShamirVsAEAD(t *testing.T) {
-	ctx := context.Background()
-	a := NewWrapper()
-	typ, err := a.Type(ctx)
-	require.NoError(t, err)
-	require.Equal(t, typ, wrapping.WrapperTypeAead)
-
-	s := NewShamirWrapper()
-	typ, err = s.Type(ctx)
-	require.NoError(t, err)
-	require.Equal(t, typ, wrapping.WrapperTypeShamir)
-}
-
 func Test_Wrapper(t *testing.T) {
 	root := NewWrapper()
 	encBlob := testWrapperBasic(t, root)

--- a/const.go
+++ b/const.go
@@ -17,7 +17,6 @@ const (
 	WrapperTypeKmip            WrapperType = "kmip"
 	WrapperTypeOciKms          WrapperType = "ocikms"
 	WrapperTypePkcs11          WrapperType = "pkcs11"
-	WrapperTypeShamir          WrapperType = "shamir"
 	WrapperTypeSecurosysHsm    WrapperType = "securosys-hsm"
 	WrapperTypeTencentCloudKms WrapperType = "tencentcloudkms"
 	WrapperTypeTransit         WrapperType = "transit"

--- a/wrappers/aead/aead.go
+++ b/wrappers/aead/aead.go
@@ -10,24 +10,14 @@ import (
 	baseaead "github.com/openbao/go-kms-wrapping/v2/aead"
 )
 
-type (
-	Wrapper       = baseaead.Wrapper
-	ShamirWrapper = baseaead.ShamirWrapper
-)
+type Wrapper = baseaead.Wrapper
 
 var (
 	NewWrapper       func() *Wrapper                         = baseaead.NewWrapper
-	NewShamirWrapper func() *ShamirWrapper                   = baseaead.NewShamirWrapper
 	WithAeadType     func(wrapping.AeadType) wrapping.Option = baseaead.WithAeadType
 	WithHashType     func(wrapping.HashType) wrapping.Option = baseaead.WithHashType
 	WithInfo         func([]byte) wrapping.Option            = baseaead.WithInfo
 	WithKey          func([]byte) wrapping.Option            = baseaead.WithKey
 	WithSalt         func([]byte) wrapping.Option            = baseaead.WithSalt
 	WithRandomReader func(io.Reader) wrapping.Option         = baseaead.WithRandomReader
-)
-
-// Ensure that we are implementing Wrapper
-var (
-	_ wrapping.Wrapper = (*Wrapper)(nil)
-	_ wrapping.Wrapper = (*ShamirWrapper)(nil)
 )


### PR DESCRIPTION
This wrapper has been deprecated for a long time and is really a detail internal to OpenBao that shouldn't be exposed in go-kms-wrapping. We've recently incorporated it into an internal package in the main repo and can remove it here.

See also: https://github.com/openbao/openbao/pull/2547