### PR TITLE
Add very basic CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @openbao/openbao-org-maintainers


### PR DESCRIPTION
Adds a very basic CODEOWNERS file such that org maintainers get tagged on PRs. Once there are teams or specific users ready to take ownership of certain subpackages, we will also add them here.