### PR TITLE
Set up Dependabot for Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 5
+    labels:
+      - dependencies


### PR DESCRIPTION
In particular, workflows in this repo are still on actions versions that use Node v20, which is deprecated - Let's have Dependabot fix that for us.

Also see: https://github.com/openbao/openbao-plugins/pull/60