### PR TITLE
Fix some WithDisallowEnvVars inconsistencies

### DIFF
--- a/plugin/server.go
+++ b/plugin/server.go
@@ -55,6 +55,7 @@ func (s *gRPCWrapperServer) SetConfig(ctx context.Context, req *pb.SetConfigRequ
 		ctx,
 		wrapping.WithKeyId(opts.WithKeyId),
 		wrapping.WithConfigMap(opts.WithConfigMap),
+		wrapping.WithDisallowEnvVars(opts.WithDisallowEnvVars),
 	)
 	if err != nil {
 		return nil, err

--- a/wrapper.go
+++ b/wrapper.go
@@ -23,6 +23,7 @@ type Wrapper interface {
 	// This method takes the following generic options:
 	// 	- WithKeyId
 	// 	- WithConfigMap
+	//  - WithDisallowEnvVars
 	//
 	// Not all wrappers will support all available options. Additionally,
 	// provider-specific options defined by specific wrapper packages may be

--- a/wrappers/awskms/awskms.go
+++ b/wrappers/awskms/awskms.go
@@ -88,9 +88,9 @@ func (k *Wrapper) SetConfig(_ context.Context, opt ...wrapping.Option) (*wrappin
 
 	// Check and set KeyId
 	switch {
-	case os.Getenv(EnvAwsKmsWrapperKeyId) != "" && !opts.withDisallowEnvVars:
+	case os.Getenv(EnvAwsKmsWrapperKeyId) != "" && !opts.WithDisallowEnvVars:
 		k.keyId = os.Getenv(EnvAwsKmsWrapperKeyId)
-	case os.Getenv(EnvVaultAwsKmsSealKeyId) != "" && !opts.withDisallowEnvVars:
+	case os.Getenv(EnvVaultAwsKmsSealKeyId) != "" && !opts.WithDisallowEnvVars:
 		k.keyId = os.Getenv(EnvVaultAwsKmsSealKeyId)
 	case opts.WithKeyId != "":
 		k.keyId = opts.WithKeyId
@@ -118,7 +118,7 @@ func (k *Wrapper) SetConfig(_ context.Context, opt ...wrapping.Option) (*wrappin
 	k.roleSessionName = opts.withRoleSessionName
 	k.roleArn = opts.withRoleArn
 
-	if !opts.withDisallowEnvVars {
+	if !opts.WithDisallowEnvVars {
 		k.endpoint = os.Getenv("AWS_KMS_ENDPOINT")
 	}
 	if k.endpoint == "" {

--- a/wrappers/awskms/awskms_test.go
+++ b/wrappers/awskms/awskms_test.go
@@ -47,14 +47,15 @@ func TestAwsKmsWrapper_IgnoreEnv(t *testing.T) {
 	}
 
 	config := map[string]string{
-		"disallow_env_vars": "true",
-		"kms_key_id":        "a-key-key",
-		"access_key":        "a-access-key",
-		"secret_key":        "a-secret-key",
-		"endpoint":          "my-endpoint",
+		"kms_key_id": "a-key-key",
+		"access_key": "a-access-key",
+		"secret_key": "a-secret-key",
+		"endpoint":   "my-endpoint",
 	}
 
-	_, err := wrapper.SetConfig(context.Background(), wrapping.WithConfigMap(config))
+	_, err := wrapper.SetConfig(t.Context(),
+		wrapping.WithConfigMap(config),
+		wrapping.WithDisallowEnvVars(true))
 	assert.NoError(t, err)
 
 	require.Equal(t, config["access_key"], wrapper.accessKey)

--- a/wrappers/awskms/options.go
+++ b/wrappers/awskms/options.go
@@ -47,12 +47,6 @@ func getOpts(opt ...wrapping.Option) (*options, error) {
 	if opts.WithConfigMap != nil {
 		for k, v := range opts.WithConfigMap {
 			switch k {
-			case "disallow_env_vars":
-				disallowEnvVars, err := strconv.ParseBool(v)
-				if err != nil {
-					return nil, err
-				}
-				opts.withDisallowEnvVars = disallowEnvVars
 			case "key_not_required":
 				keyNotRequired, err := strconv.ParseBool(v)
 				if err != nil {
@@ -109,7 +103,6 @@ type OptionFunc func(*options) error
 type options struct {
 	*wrapping.Options
 
-	withDisallowEnvVars      bool
 	withKeyNotRequired       bool
 	withRegion               string
 	withEndpoint             string
@@ -127,16 +120,6 @@ type options struct {
 
 func getDefaultOptions() options {
 	return options{}
-}
-
-// WithDisallowEnvVars provides a way to disable using env vars
-func WithDisallowEnvVars(with bool) wrapping.Option {
-	return func() interface{} {
-		return OptionFunc(func(o *options) error {
-			o.withDisallowEnvVars = with
-			return nil
-		})
-	}
 }
 
 // WithKeyNotRequired provides a way to not require a key at config time

--- a/wrappers/azurekeyvault/azurekeyvault.go
+++ b/wrappers/azurekeyvault/azurekeyvault.go
@@ -142,7 +142,7 @@ func (v *Wrapper) SetConfig(ctx context.Context, opt ...wrapping.Option) (*wrapp
 
 	authMethod := ""
 	switch {
-	case os.Getenv(EnvVaultAzureKeyVaultAuthMethod) != "" && !opts.withDisallowEnvVars:
+	case os.Getenv(EnvVaultAzureKeyVaultAuthMethod) != "" && !opts.WithDisallowEnvVars:
 		authMethod = os.Getenv(EnvVaultAzureKeyVaultAuthMethod)
 	case opts.withAuthMethod != "":
 		authMethod = opts.withAuthMethod
@@ -151,35 +151,35 @@ func (v *Wrapper) SetConfig(ctx context.Context, opt ...wrapping.Option) (*wrapp
 	v.authMethod = mapAuthMethod(authMethod)
 
 	switch {
-	case os.Getenv(EnvVaultAzureKeyVaultCertificatePath) != "" && !opts.withDisallowEnvVars:
+	case os.Getenv(EnvVaultAzureKeyVaultCertificatePath) != "" && !opts.WithDisallowEnvVars:
 		v.certPath = os.Getenv(EnvVaultAzureKeyVaultCertificatePath)
 	case opts.withCertPath != "":
 		v.certPath = opts.withCertPath
 	}
 
 	switch {
-	case os.Getenv(EnvVaultAzureKeyVaultCertificatePassword) != "" && !opts.withDisallowEnvVars:
+	case os.Getenv(EnvVaultAzureKeyVaultCertificatePassword) != "" && !opts.WithDisallowEnvVars:
 		v.certPass = os.Getenv(EnvVaultAzureKeyVaultCertificatePassword)
 	case opts.withCertPass != "":
 		v.certPass = opts.withCertPass
 	}
 
 	switch {
-	case os.Getenv("AZURE_TENANT_ID") != "" && !opts.withDisallowEnvVars:
+	case os.Getenv("AZURE_TENANT_ID") != "" && !opts.WithDisallowEnvVars:
 		v.tenantID = os.Getenv("AZURE_TENANT_ID")
 	case opts.withTenantId != "":
 		v.tenantID = opts.withTenantId
 	}
 
 	switch {
-	case os.Getenv("AZURE_CLIENT_ID") != "" && !opts.withDisallowEnvVars:
+	case os.Getenv("AZURE_CLIENT_ID") != "" && !opts.WithDisallowEnvVars:
 		v.clientID = os.Getenv("AZURE_CLIENT_ID")
 	case opts.withClientId != "":
 		v.clientID = opts.withClientId
 	}
 
 	switch {
-	case os.Getenv(EnvVaultAzureKeyVaultResourceId) != "" && !opts.withDisallowEnvVars:
+	case os.Getenv(EnvVaultAzureKeyVaultResourceId) != "" && !opts.WithDisallowEnvVars:
 		v.resourceID = os.Getenv(EnvVaultAzureKeyVaultResourceId)
 	case opts.withResourceId != "":
 		v.resourceID = opts.withResourceId
@@ -187,7 +187,7 @@ func (v *Wrapper) SetConfig(ctx context.Context, opt ...wrapping.Option) (*wrapp
 
 	managedIdKind := ""
 	switch {
-	case os.Getenv(EnvVaultAzureKeyVaultManagedIdentityKind) != "" && !opts.withDisallowEnvVars:
+	case os.Getenv(EnvVaultAzureKeyVaultManagedIdentityKind) != "" && !opts.WithDisallowEnvVars:
 		managedIdKind = os.Getenv(EnvVaultAzureKeyVaultManagedIdentityKind)
 	case opts.withManagedIdKind != "":
 		managedIdKind = opts.withManagedIdKind
@@ -203,19 +203,19 @@ func (v *Wrapper) SetConfig(ctx context.Context, opt ...wrapping.Option) (*wrapp
 	}
 
 	switch {
-	case os.Getenv(EnvVaultAzureKeyVaultManagedIdentityKind) != "" && !opts.withDisallowEnvVars:
+	case os.Getenv(EnvVaultAzureKeyVaultManagedIdentityKind) != "" && !opts.WithDisallowEnvVars:
 
 	}
 
 	switch {
-	case os.Getenv("AZURE_CLIENT_SECRET") != "" && !opts.withDisallowEnvVars:
+	case os.Getenv("AZURE_CLIENT_SECRET") != "" && !opts.WithDisallowEnvVars:
 		v.clientSecret = os.Getenv("AZURE_CLIENT_SECRET")
 	case opts.withClientSecret != "":
 		v.clientSecret = opts.withClientSecret
 	}
 
 	var envName string
-	if !opts.withDisallowEnvVars {
+	if !opts.WithDisallowEnvVars {
 		envName = os.Getenv("AZURE_ENVIRONMENT")
 	}
 	if envName == "" {
@@ -232,7 +232,7 @@ func (v *Wrapper) SetConfig(ctx context.Context, opt ...wrapping.Option) (*wrapp
 	}
 
 	var azResource string
-	if !opts.withDisallowEnvVars {
+	if !opts.WithDisallowEnvVars {
 		azResource = os.Getenv("AZURE_AD_RESOURCE")
 	}
 	if azResource == "" {
@@ -246,9 +246,9 @@ func (v *Wrapper) SetConfig(ctx context.Context, opt ...wrapping.Option) (*wrapp
 	v.environment.KeyVaultEndpoint = v.resource
 
 	switch {
-	case os.Getenv(EnvAzureKeyVaultWrapperVaultName) != "" && !opts.withDisallowEnvVars:
+	case os.Getenv(EnvAzureKeyVaultWrapperVaultName) != "" && !opts.WithDisallowEnvVars:
 		v.vaultName = os.Getenv(EnvAzureKeyVaultWrapperVaultName)
-	case os.Getenv(EnvVaultAzureKeyVaultVaultName) != "" && !opts.withDisallowEnvVars:
+	case os.Getenv(EnvVaultAzureKeyVaultVaultName) != "" && !opts.WithDisallowEnvVars:
 		v.vaultName = os.Getenv(EnvVaultAzureKeyVaultVaultName)
 	case opts.withVaultName != "":
 		v.vaultName = opts.withVaultName
@@ -257,9 +257,9 @@ func (v *Wrapper) SetConfig(ctx context.Context, opt ...wrapping.Option) (*wrapp
 	}
 
 	switch {
-	case os.Getenv(EnvAzureKeyVaultWrapperKeyName) != "" && !opts.withDisallowEnvVars:
+	case os.Getenv(EnvAzureKeyVaultWrapperKeyName) != "" && !opts.WithDisallowEnvVars:
 		v.keyName = os.Getenv(EnvAzureKeyVaultWrapperKeyName)
-	case os.Getenv(EnvVaultAzureKeyVaultKeyName) != "" && !opts.withDisallowEnvVars:
+	case os.Getenv(EnvVaultAzureKeyVaultKeyName) != "" && !opts.WithDisallowEnvVars:
 		v.keyName = os.Getenv(EnvVaultAzureKeyVaultKeyName)
 	case opts.withKeyName != "":
 		v.keyName = opts.withKeyName

--- a/wrappers/azurekeyvault/azurekeyvault_acc_test.go
+++ b/wrappers/azurekeyvault/azurekeyvault_acc_test.go
@@ -94,19 +94,20 @@ func TestAzureKeyVault_IgnoreEnv(t *testing.T) {
 		defer os.Setenv(envVar, oldVal)
 	}
 	config := map[string]string{
-		"disallow_env_vars": "true",
-		"tenant_id":         "a-tenant-id",
-		"client_id":         "a-client-id",
-		"client_secret":     "a-client-secret",
-		"environment":       azure.PublicCloud.Name,
-		"resource":          "a-resource",
-		"vault_name":        "a-vault-name",
-		"key_name":          "a-key-name",
-		"auth_method":       "managed_identity",
-		"cert_path":         "/cert/someCert.pem",
-		"cert_password":     "somePassword",
+		"tenant_id":     "a-tenant-id",
+		"client_id":     "a-client-id",
+		"client_secret": "a-client-secret",
+		"environment":   azure.PublicCloud.Name,
+		"resource":      "a-resource",
+		"vault_name":    "a-vault-name",
+		"key_name":      "a-key-name",
+		"auth_method":   "managed_identity",
+		"cert_path":     "/cert/someCert.pem",
+		"cert_password": "somePassword",
 	}
-	_, err := s.SetConfig(context.Background(), wrapping.WithConfigMap(config))
+	_, err := s.SetConfig(t.Context(),
+		wrapping.WithConfigMap(config),
+		wrapping.WithDisallowEnvVars(true))
 	require.Equal(t, expectedErr, err.Error())
 	require.Equal(t, config["tenant_id"], s.tenantID)
 	require.Equal(t, config["client_id"], s.clientID)
@@ -208,7 +209,7 @@ func TestCreds_getCertificate(t *testing.T) {
 	if os.Getenv("VAULT_ACC") == "" {
 		t.SkipNow()
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 
 	clientID := os.Getenv("TEST_AZURE_CLIENT_ID")
 	tenantID := os.Getenv("TEST_AZURE_TENANT_ID")
@@ -218,15 +219,14 @@ func TestCreds_getCertificate(t *testing.T) {
 	expectedOutput := "foo"
 
 	config := map[string]string{
-		"disallow_env_vars": "true",
-		"environment":       azure.PublicCloud.Name,
-		"resource":          "vault.azure.net",
-		"vault_name":        vaultName,
-		"key_name":          keyName,
-		"auth_method":       "certificate",
-		"cert_path":         "test-data/azure-app.crt",
-		"client_id":         clientID,
-		"tenant_id":         tenantID,
+		"environment": azure.PublicCloud.Name,
+		"resource":    "vault.azure.net",
+		"vault_name":  vaultName,
+		"key_name":    keyName,
+		"auth_method": "certificate",
+		"cert_path":   "test-data/azure-app.crt",
+		"client_id":   clientID,
+		"tenant_id":   tenantID,
 	}
 
 	wrapper := NewWrapper()
@@ -234,7 +234,9 @@ func TestCreds_getCertificate(t *testing.T) {
 	setConfig := func() {
 		t.Helper()
 		t.Log("--- SetConfig ---")
-		_, err := wrapper.SetConfig(ctx, wrapping.WithConfigMap(config))
+		_, err := wrapper.SetConfig(ctx,
+			wrapping.WithConfigMap(config),
+			wrapping.WithDisallowEnvVars(true))
 		require.NoError(t, err)
 	}
 

--- a/wrappers/azurekeyvault/options.go
+++ b/wrappers/azurekeyvault/options.go
@@ -47,12 +47,6 @@ func getOpts(opt ...wrapping.Option) (*options, error) {
 	if opts.WithConfigMap != nil {
 		for k, v := range opts.WithConfigMap {
 			switch k {
-			case "disallow_env_vars":
-				disallowEnvVars, err := strconv.ParseBool(v)
-				if err != nil {
-					return nil, err
-				}
-				opts.withDisallowEnvVars = disallowEnvVars
 			case "key_not_required":
 				keyNotRequired, err := strconv.ParseBool(v)
 				if err != nil {
@@ -111,36 +105,25 @@ type OptionFunc func(*options) error
 type options struct {
 	*wrapping.Options
 
-	withDisallowEnvVars bool
-	withKeyNotRequired  bool
-	withTenantId        string
-	withClientId        string
-	withResourceId      string
-	withManagedIdKind   string
-	withClientSecret    string
-	withEnvironment     string
-	withResource        string
-	withVaultName       string
-	withKeyName         string
-	withAuthMethod      string
-	withCertPath        string
-	withCertPass        string
+	withKeyNotRequired bool
+	withTenantId       string
+	withClientId       string
+	withResourceId     string
+	withManagedIdKind  string
+	withClientSecret   string
+	withEnvironment    string
+	withResource       string
+	withVaultName      string
+	withKeyName        string
+	withAuthMethod     string
+	withCertPath       string
+	withCertPass       string
 
 	withLogger hclog.Logger
 }
 
 func getDefaultOptions() options {
 	return options{}
-}
-
-// WithDisallowEnvVars provides a way to disable using env vars
-func WithDisallowEnvVars(with bool) wrapping.Option {
-	return func() interface{} {
-		return OptionFunc(func(o *options) error {
-			o.withDisallowEnvVars = with
-			return nil
-		})
-	}
 }
 
 // WithKeyNotRequired provides a way to not require a key at config time


### PR DESCRIPTION
Two changes:

1. Propagate `WithDisallowEnvVars` on the plugin server and document it as a supported global option for `SetConfig`.
2. Remove the undocumented `disallow_env_vars` flag from config map handling for AWS and Azure wrappers and use the global `DisallowEnvVars` instead. If we want a user-controllable `disallow_env_vars` config map param, we'd probably need to implement this as a meta-level field in OpenBao's server config parsing so we can allow it on the root seal but not on future namespace seals.

Extra context: https://github.com/openbao/go-kms-wrapping/pull/63#discussion_r3106956528