### PR TITLE
Remove wrapper constants from main module

### DIFF
--- a/const.go
+++ b/const.go
@@ -5,24 +5,13 @@ package wrapping
 
 type WrapperType string
 
-// These values define known types of Wrappers
+// These constants define types of Wrappers known by the main go-kms-wrapping
+// module. Submodules that provide additional Wrapper implementations should
+// export their own type constant for convenience.
 const (
-	WrapperTypeUnknown         WrapperType = "unknown"
-	WrapperTypeAead            WrapperType = "aead"
-	WrapperTypeAliCloudKms     WrapperType = "alicloudkms"
-	WrapperTypeAwsKms          WrapperType = "awskms"
-	WrapperTypeAzureKeyVault   WrapperType = "azurekeyvault"
-	WrapperTypeGcpCkms         WrapperType = "gcpckms"
-	WrapperTypeHuaweiCloudKms  WrapperType = "huaweicloudkms"
-	WrapperTypeKmip            WrapperType = "kmip"
-	WrapperTypeOciKms          WrapperType = "ocikms"
-	WrapperTypePkcs11          WrapperType = "pkcs11"
-	WrapperTypeSecurosysHsm    WrapperType = "securosys-hsm"
-	WrapperTypeTCloudPublicKms WrapperType = "tcloudpublickms"
-	WrapperTypeTencentCloudKms WrapperType = "tencentcloudkms"
-	WrapperTypeTransit         WrapperType = "transit"
-	WrapperTypeStatic          WrapperType = "static"
-	WrapperTypeTest            WrapperType = "test-auto"
+	WrapperTypeUnknown WrapperType = "unknown"
+	WrapperTypeAead    WrapperType = "aead"
+	WrapperTypeTest    WrapperType = "test-auto"
 )
 
 func (t WrapperType) String() string {

--- a/wrapper.go
+++ b/wrapper.go
@@ -11,7 +11,7 @@ import (
 // or more opaque encryption keys.
 type Wrapper interface {
 	// Type returns the type of the Wrapper, e.g., "pkcs11". Well-known types
-	// are available as constants in this package, e.g., WrapperTypePkcs11.
+	// are available as constants in this package, e.g., WrapperTypeAead.
 	//
 	// This is expected to always return the same value such that callers can
 	// safely cache the type after initially retrieving it once.

--- a/wrappers/alicloudkms/alicloudkms.go
+++ b/wrappers/alicloudkms/alicloudkms.go
@@ -17,6 +17,8 @@ import (
 	wrapping "github.com/openbao/go-kms-wrapping/v2"
 )
 
+const Type wrapping.WrapperType = "alicloudkms"
+
 // These constants contain the accepted env vars; the Vault one is for backwards compat
 const (
 	EnvAliCloudKmsWrapperKeyId   = "ALICLOUDKMS_WRAPPER_KEY_ID"
@@ -148,7 +150,7 @@ func (k *Wrapper) SetConfig(_ context.Context, opt ...wrapping.Option) (*wrappin
 
 // Type returns the type for this particular wrapper implementation
 func (k *Wrapper) Type(_ context.Context) (wrapping.WrapperType, error) {
-	return wrapping.WrapperTypeAliCloudKms, nil
+	return Type, nil
 }
 
 // KeyId returns the last known key id

--- a/wrappers/awskms/awskms.go
+++ b/wrappers/awskms/awskms.go
@@ -20,6 +20,8 @@ import (
 	wrapping "github.com/openbao/go-kms-wrapping/v2"
 )
 
+const Type wrapping.WrapperType = "awskms"
+
 // These constants contain the accepted env vars; the Vault one is for backwards compat
 const (
 	EnvAwsKmsWrapperKeyId   = "AWSKMS_WRAPPER_KEY_ID"
@@ -163,7 +165,7 @@ func (k *Wrapper) SetConfig(_ context.Context, opt ...wrapping.Option) (*wrappin
 
 // Type returns the wrapping type for this particular Wrapper implementation
 func (k *Wrapper) Type(_ context.Context) (wrapping.WrapperType, error) {
-	return wrapping.WrapperTypeAwsKms, nil
+	return Type, nil
 }
 
 // KeyId returns the last known key id

--- a/wrappers/azurekeyvault/azurekeyvault.go
+++ b/wrappers/azurekeyvault/azurekeyvault.go
@@ -28,6 +28,8 @@ import (
 	wrapping "github.com/openbao/go-kms-wrapping/v2"
 )
 
+const Type wrapping.WrapperType = "azurekeyvault"
+
 const (
 	EnvAzureKeyVaultWrapperVaultName = "AZUREKEYVAULT_WRAPPER_VAULT_NAME"
 	EnvVaultAzureKeyVaultVaultName   = "VAULT_AZUREKEYVAULT_VAULT_NAME"
@@ -306,7 +308,7 @@ func (v *Wrapper) SetConfig(ctx context.Context, opt ...wrapping.Option) (*wrapp
 
 // Type returns the type for this particular Wrapper implementation
 func (v *Wrapper) Type(_ context.Context) (wrapping.WrapperType, error) {
-	return wrapping.WrapperTypeAzureKeyVault, nil
+	return Type, nil
 }
 
 // KeyId returns the last known key id

--- a/wrappers/gcpckms/gcpckms.go
+++ b/wrappers/gcpckms/gcpckms.go
@@ -16,6 +16,8 @@ import (
 	"google.golang.org/api/option"
 )
 
+const Type wrapping.WrapperType = "gcpckms"
+
 const (
 	// General GCP values, follows TF naming conventions
 	EnvGcpCkmsWrapperCredsPath = "GOOGLE_CREDENTIALS"
@@ -197,7 +199,7 @@ func (s *Wrapper) SetConfig(_ context.Context, opt ...wrapping.Option) (*wrappin
 
 // Type returns the type for this particular wrapper implementation
 func (s *Wrapper) Type(_ context.Context) (wrapping.WrapperType, error) {
-	return wrapping.WrapperTypeGcpCkms, nil
+	return Type, nil
 }
 
 // KeyId returns the last known CryptoKeyVersion which is determined when the

--- a/wrappers/huaweicloudkms/huaweicloudkms.go
+++ b/wrappers/huaweicloudkms/huaweicloudkms.go
@@ -18,6 +18,8 @@ import (
 	wrapping "github.com/openbao/go-kms-wrapping/v2"
 )
 
+const Type wrapping.WrapperType = "huaweicloudkms"
+
 // These constants contain the accepted env vars; the Vault one is for backwards compat
 const (
 	EnvHuaweiCloudKmsWrapperKeyId = "HUAWEICLOUDKMS_WRAPPER_KEY_ID"
@@ -95,7 +97,7 @@ func (k *Wrapper) SetConfig(_ context.Context, opt ...wrapping.Option) (*wrappin
 
 // Type returns the type for this particular wrapper implementation
 func (k *Wrapper) Type(_ context.Context) (wrapping.WrapperType, error) {
-	return wrapping.WrapperTypeHuaweiCloudKms, nil
+	return Type, nil
 }
 
 // KeyId returns the last known key id

--- a/wrappers/kmip/kmip.go
+++ b/wrappers/kmip/kmip.go
@@ -23,6 +23,8 @@ import (
 	"github.com/ovh/kmip-go/ttlv"
 )
 
+const Type wrapping.WrapperType = "kmip"
+
 // These constants contain the accepted env vars; the Vault one is for backwards compat
 const (
 	EnvKmipWrapperKeyId   = "BAO_KMIP_WRAPPER_KEY_ID"
@@ -274,7 +276,7 @@ func (k *Wrapper) SetConfig(ctx context.Context, opt ...wrapping.Option) (*wrapp
 
 // Type returns the type for this particular wrapper implementation
 func (k *Wrapper) Type(_ context.Context) (wrapping.WrapperType, error) {
-	return wrapping.WrapperTypeKmip, nil
+	return Type, nil
 }
 
 // KeyId returns the last known key id

--- a/wrappers/ocikms/ocikms.go
+++ b/wrappers/ocikms/ocikms.go
@@ -17,6 +17,8 @@ import (
 	"github.com/oracle/oci-go-sdk/v60/keymanagement"
 )
 
+const Type wrapping.WrapperType = "ocikms"
+
 const (
 	// OCI KMS key ID to use for encryption and decryption
 	EnvOciKmsWrapperKeyId   = "OCIKMS_WRAPPER_KEY_ID"
@@ -138,7 +140,7 @@ func (k *Wrapper) SetConfig(_ context.Context, opt ...wrapping.Option) (*wrappin
 }
 
 func (k *Wrapper) Type(_ context.Context) (wrapping.WrapperType, error) {
-	return wrapping.WrapperTypeOciKms, nil
+	return Type, nil
 }
 
 func (k *Wrapper) KeyId(_ context.Context) (string, error) {

--- a/wrappers/pkcs11/pkcs11.go
+++ b/wrappers/pkcs11/pkcs11.go
@@ -11,6 +11,8 @@ import (
 	wrapping "github.com/openbao/go-kms-wrapping/v2"
 )
 
+const Type wrapping.WrapperType = "pkcs11"
+
 // Wrapper is a Wrapper that uses PKCS11
 type Wrapper struct {
 	client       pkcs11ClientEncryptor
@@ -64,7 +66,7 @@ func (k *Wrapper) SetConfig(_ context.Context, opt ...wrapping.Option) (*wrappin
 
 // Type returns the type for this particular wrapper implementation
 func (k *Wrapper) Type(_ context.Context) (wrapping.WrapperType, error) {
-	return wrapping.WrapperTypePkcs11, nil
+	return Type, nil
 }
 
 // KeyId returns the last known key id

--- a/wrappers/securosyshsm/securosysHSM.go
+++ b/wrappers/securosyshsm/securosysHSM.go
@@ -21,11 +21,8 @@ type Wrapper struct {
 	currentKeyId *atomic.Value
 	hsmClient    *SecurosysHSMClient
 }
-type CustomWrapperType string
 
-const (
-	WrapperTypeSecurosysHSM CustomWrapperType = "securosys-hsm"
-)
+const Type wrapping.WrapperType = "securosys-hsm"
 
 var _ wrapping.Wrapper = (*Wrapper)(nil)
 
@@ -69,7 +66,7 @@ func (s *Wrapper) Finalize(_ context.Context) error {
 
 // Type returns the type for this particular Wrapper implementation
 func (s *Wrapper) Type(_ context.Context) (wrapping.WrapperType, error) {
-	return wrapping.WrapperTypeSecurosysHsm, nil
+	return Type, nil
 }
 
 // KeyId returns the last known key id

--- a/wrappers/static/static.go
+++ b/wrappers/static/static.go
@@ -19,6 +19,8 @@ import (
 	wrapping "github.com/openbao/go-kms-wrapping/v2"
 )
 
+const Type wrapping.WrapperType = "static"
+
 const (
 	EnvBaoCurrentKeyValueName       = "BAO_STATIC_SEAL_CURRENT_KEY"
 	EnvBaoCurrentKeyIdentifierName  = "BAO_STATIC_SEAL_CURRENT_KEY_ID"
@@ -175,7 +177,7 @@ func (s *Wrapper) Finalize(_ context.Context) error {
 
 // Type returns the type for this particular Wrapper implementation
 func (s *Wrapper) Type(_ context.Context) (wrapping.WrapperType, error) {
-	return wrapping.WrapperTypeStatic, nil
+	return Type, nil
 }
 
 // KeyId returns the last known key id

--- a/wrappers/tcloudpublickms/tcloudpublickms.go
+++ b/wrappers/tcloudpublickms/tcloudpublickms.go
@@ -17,6 +17,8 @@ import (
 	kms "github.com/opentelekomcloud/gophertelekomcloud/openstack/kms/v1/keys"
 )
 
+const Type wrapping.WrapperType = "tcloudpublickms"
+
 const (
 	EnvTCloudPublicKmsKeyId         = "TCLOUDPUBLIC_KMS_KEY_ID"
 	EnvTCloudPublicRegion           = "TCLOUDPUBLIC_REGION"
@@ -100,7 +102,7 @@ func (k *Wrapper) SetConfig(
 
 // Type returns the type for this particular wrapper implementation
 func (k *Wrapper) Type(_ context.Context) (wrapping.WrapperType, error) {
-	return wrapping.WrapperTypeTCloudPublicKms, nil
+	return Type, nil
 }
 
 // KeyId returns the last known key id

--- a/wrappers/tencentcloudkms/tencentcloudkms.go
+++ b/wrappers/tencentcloudkms/tencentcloudkms.go
@@ -16,6 +16,8 @@ import (
 	kms "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/kms/v20190118"
 )
 
+const Type wrapping.WrapperType = "tencentcloudkms"
+
 // These constants are TencentCloud accepted env vars
 const (
 	PROVIDER_SECRET_ID      = "TENCENTCLOUD_SECRET_ID"
@@ -140,7 +142,7 @@ func (k *Wrapper) SetConfig(_ context.Context, opt ...wrapping.Option) (*wrappin
 
 // Type returns the type for this particular wrapper implementation
 func (k *Wrapper) Type(_ context.Context) (wrapping.WrapperType, error) {
-	return wrapping.WrapperTypeTencentCloudKms, nil
+	return Type, nil
 }
 
 // KeyId returns the last known key id

--- a/wrappers/transit/transit.go
+++ b/wrappers/transit/transit.go
@@ -13,6 +13,8 @@ import (
 	wrapping "github.com/openbao/go-kms-wrapping/v2"
 )
 
+const Type wrapping.WrapperType = "transit"
+
 // Wrapper is a wrapper that leverages Vault's Transit secret
 // engine
 type Wrapper struct {
@@ -75,7 +77,7 @@ func (s *Wrapper) Finalize(_ context.Context, _ ...wrapping.Option) error {
 
 // Type returns the type for this particular Wrapper implementation
 func (s *Wrapper) Type(_ context.Context) (wrapping.WrapperType, error) {
-	return wrapping.WrapperTypeTransit, nil
+	return Type, nil
 }
 
 // KeyId returns the last known key id


### PR DESCRIPTION
These constants create a non-generic dependency from `go-kms-wrapping/wrappers/* -> go-kms-wrapping`, which is to say that the main go-kms-wrapping module must get a new tag before any new wrapper can be published.

That's silly, particularly given we're moving towards pluginized, decoupled wrapper distribution.

I don't know of any place these are actually used, so drop them.

Also see: https://github.com/openbao/openbao-plugins/pull/89#issuecomment-4528001117