### PR TITLE
Ensure no uncontrolled env reads within AliCloud wrapper

### DIFF
--- a/wrappers/alicloudkms/alicloudkms.go
+++ b/wrappers/alicloudkms/alicloudkms.go
@@ -48,9 +48,9 @@ func NewWrapper() *Wrapper {
 // SetConfig sets the fields on the AliCloudKMSWrapper object based on
 // values from the config parameter.
 //
-// Order of precedence AliCloud values:
-// * Environment variable
-// * Value from Vault configuration file
+// Order of precedence for AliCloud values:
+// * Environment variables (if WithDisallowEnvVars not provided)
+// * Value from OpenBao/Vault configuration file
 // * Instance metadata role (access key and secret key)
 func (k *Wrapper) SetConfig(_ context.Context, opt ...wrapping.Option) (*wrapping.WrapperConfig, error) {
 	opts, err := getOpts(opt...)
@@ -99,11 +99,19 @@ func (k *Wrapper) SetConfig(_ context.Context, opt ...wrapping.Option) (*wrappin
 			credConfig.AccessKeySecret = opts.withAccessSecret
 		}
 
-		credentialChain := []providers.Provider{
-			providers.NewEnvCredentialProvider(),
-			providers.NewConfigurationCredentialProvider(credConfig),
-			providers.NewInstanceMetadataProvider(),
+		credentialChain := []providers.Provider{}
+		if !opts.WithDisallowEnvVars {
+			credentialChain = append(credentialChain, providers.NewEnvCredentialProvider())
 		}
+
+		credentialChain = append(credentialChain,
+			providers.NewConfigurationCredentialProvider(credConfig),
+		)
+
+		if !opts.WithDisallowEnvVars {
+			credentialChain = append(credentialChain, providers.NewInstanceMetadataProvider())
+		}
+
 		credProvider := providers.NewChainProvider(credentialChain)
 
 		creds, err := credProvider.Retrieve()

--- a/wrappers/alicloudkms/alicloudkms_test.go
+++ b/wrappers/alicloudkms/alicloudkms_test.go
@@ -22,7 +22,7 @@ func TestAliCloudKmsWrapper(t *testing.T) {
 		keyId: aliCloudTestKeyId,
 	}
 
-	if _, err := s.SetConfig(nil); err == nil {
+	if _, err := s.SetConfig(t.Context()); err == nil {
 		t.Fatal("expected error when AliCloudKMSWrapper key ID is not provided")
 	}
 
@@ -35,7 +35,7 @@ func TestAliCloudKmsWrapper(t *testing.T) {
 			t.Fatal(err)
 		}
 	}()
-	if _, err := s.SetConfig(nil); err != nil {
+	if _, err := s.SetConfig(t.Context()); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -54,7 +54,7 @@ func TestAliCloudKmsWrapper_Lifecycle(t *testing.T) {
 			t.Fatal(err)
 		}
 	}()
-	if _, err := s.SetConfig(nil); err != nil {
+	if _, err := s.SetConfig(t.Context()); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
As a part of #110 this PR enforces that no env reads are conducted while `WithDisallowEnvVars` was provided as a wrapper option.