### PR TITLE
Improve GRPC plugin errors

### DIFF
--- a/plugin/kms_client.go
+++ b/plugin/kms_client.go
@@ -37,8 +37,11 @@ func (kp *gRPCKMSPlugin) GRPCClient(ctx context.Context, broker *plugin.GRPCBrok
 }
 
 func (c *gRPCKMSClient) handleRPCError(err error) error {
-	code := status.Code(err)
+	s, _ := status.FromError(err)
+	code := s.Code()
 	switch {
+	case code == codes.Unknown:
+		return errors.New(s.Message())
 	case code == codes.Unimplemented:
 		return kms.ErrNotImplemented
 	case code == codes.NotFound:

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -47,7 +47,7 @@ func Serve(opts *ServeOpts) {
 	logger := opts.Logger
 	if logger == nil {
 		logger = log.New(&log.LoggerOptions{
-			Level:      log.Info,
+			Level:      log.Trace,
 			Output:     os.Stderr,
 			JSONFormat: true,
 		})

--- a/plugin/wrapper_client.go
+++ b/plugin/wrapper_client.go
@@ -29,8 +29,11 @@ func (wp *gRPCWrapperPlugin) GRPCClient(ctx context.Context, broker *plugin.GRPC
 }
 
 func (c *gRPCWrapperClient) handleRPCError(err error) error {
-	code := status.Code(err)
+	s, _ := status.FromError(err)
+	code := s.Code()
 	switch {
+	case code == codes.Unknown:
+		return errors.New(s.Message())
 	case code == codes.Unimplemented:
 		return wrapping.ErrFunctionNotImplemented
 	case code == codes.NotFound:


### PR DESCRIPTION
When an application-level error occurs on the plugin, this becomes a GRPC error of status "Unknown" with the original error message as its description/message. As a result, an error will be presented differently in OpenBao if it was returned by the GRPC-pluginized version of a plugin opposed to a builtin version:

```
Error writing data to sys/external-keys/configs/foo: Error making API request.

URL: PUT http://127.0.0.1:8200/v1/sys/external-keys/configs/foo
Code: 400. Errors:

* rpc error: code = Unknown desc = failed to pkcs#11 Login: pkcs11: 0xA0: CKR_PIN_INCORRECT
```

by unwrapping the error at the plugin layer, we'll instead see:

```
Error writing data to sys/external-keys/configs/foo: Error making API request.

URL: PUT http://127.0.0.1:8200/v1/sys/external-keys/configs/foo
Code: 400. Errors:

* failed to pkcs#11 Login: pkcs11: 0xA0: CKR_PIN_INCORRECT
```