### PR TITLE
Ensure no uncontrolled env or file reads within OCIKMS wrapper

### DIFF
--- a/wrappers/ocikms/ocikms.go
+++ b/wrappers/ocikms/ocikms.go
@@ -34,15 +34,7 @@ const (
 )
 
 type Wrapper struct {
-	authTypeAPIKey       bool   // true for user principal, false for instance principal, default is false
-	keyId                string // OCI KMS keyId
-	tenancyOCID          string
-	userOCID             string
-	keyFingerprint       string
-	region               string
-	privateKey           string
-	privateKeyPassphrase string
-
+	keyId              string // OCI KMS keyId
 	cryptoEndpoint     string // OCI KMS crypto endpoint
 	managementEndpoint string // OCI KMS management endpoint
 
@@ -52,9 +44,9 @@ type Wrapper struct {
 	currentKeyId *atomic.Value // Current key version which is used for encryption/decryption
 }
 
+// Ensure that we are implementing Wrapper
 var _ wrapping.Wrapper = (*Wrapper)(nil)
 
-// NewWrapper creates a new Wrapper seal with the provided logger
 func NewWrapper() *Wrapper {
 	k := &Wrapper{
 		currentKeyId: new(atomic.Value),
@@ -63,6 +55,12 @@ func NewWrapper() *Wrapper {
 	return k
 }
 
+// SetConfig sets the fields on the OCIKMSWrapper object based on
+// values from the config parameter.
+//
+// Order of precedence for OCIKMS values:
+// * Environment variables (if WithDisallowEnvVars not provided)
+// * Value from OpenBao/Vault configuration file
 func (k *Wrapper) SetConfig(ctx context.Context, opt ...wrapping.Option) (*wrapping.WrapperConfig, error) {
 	opts, err := getOpts(opt...)
 	if err != nil {
@@ -104,17 +102,25 @@ func (k *Wrapper) SetConfig(ctx context.Context, opt ...wrapping.Option) (*wrapp
 		return nil, fmt.Errorf("%q not found for OCI KMS seal configuration", KmsConfigManagementEndpoint)
 	}
 
-	k.authTypeAPIKey = opts.withAuthTypeApiKey
-	k.tenancyOCID = opts.withTenancyOCID
-	k.userOCID = opts.withUserOCID
-	k.keyFingerprint = opts.withKeyFingerprint
-	k.region = opts.withRegion
-	k.privateKey = opts.withPrivateKey
-	k.privateKeyPassphrase = opts.WithPrivateKeyPassphrase
-
-	cp, err := k.getConfigProvider(opts.Options.WithDisallowEnvVars)
-	if err != nil {
-		return nil, fmt.Errorf("failed creating configuration provider: %w", err)
+	var cp common.ConfigurationProvider
+	if opts.withAuthTypeApiKey {
+		cp, err = auth.InstancePrincipalConfigurationProvider()
+		if err != nil {
+			return nil, fmt.Errorf("failed creating InstancePrincipalConfigurationProvider: %w", err)
+		}
+	} else {
+		if !opts.Options.WithDisallowEnvVars {
+			cp = common.DefaultConfigProvider()
+		} else {
+			cp = common.NewRawConfigurationProvider(
+				opts.withTenancyOCID,
+				opts.withUserOCID,
+				opts.withRegion,
+				opts.withKeyFingerprint,
+				opts.withPrivateKey,
+				&opts.withPrivateKeyPassphrase,
+			)
+		}
 	}
 
 	// Check and set OCI KMS crypto client
@@ -147,7 +153,7 @@ func (k *Wrapper) SetConfig(ctx context.Context, opt ...wrapping.Option) (*wrapp
 	wrapConfig.Metadata[KmsConfigKeyId] = k.keyId
 	wrapConfig.Metadata[KmsConfigCryptoEndpoint] = k.cryptoEndpoint
 	wrapConfig.Metadata[KmsConfigManagementEndpoint] = k.managementEndpoint
-	if k.authTypeAPIKey {
+	if opts.withAuthTypeApiKey {
 		wrapConfig.Metadata["principal_type"] = "user"
 	} else {
 		wrapConfig.Metadata["principal_type"] = "instance"
@@ -256,24 +262,6 @@ func (k *Wrapper) Decrypt(ctx context.Context, in *wrapping.BlobInfo, opt ...wra
 	return plaintext, nil
 }
 
-func (k *Wrapper) getConfigProvider(withDisallowEnvVars bool) (common.ConfigurationProvider, error) {
-	var cp common.ConfigurationProvider
-	var err error
-	if k.authTypeAPIKey {
-		if !withDisallowEnvVars {
-			cp = common.DefaultConfigProvider()
-		} else {
-			cp = common.NewRawConfigurationProvider(k.tenancyOCID, k.userOCID, k.region, k.keyFingerprint, k.privateKey, &k.privateKeyPassphrase)
-		}
-	} else {
-		cp, err = auth.InstancePrincipalConfigurationProvider()
-		if err != nil {
-			return nil, fmt.Errorf("failed creating InstancePrincipalConfigurationProvider: %w", err)
-		}
-	}
-	return cp, nil
-}
-
 // Build OCI KMS crypto client
 func (k *Wrapper) getOciKmsCryptoClient(cp common.ConfigurationProvider) (*keymanagement.KmsCryptoClient, error) {
 	kmsCryptoClient, err := keymanagement.NewKmsCryptoClientWithConfigurationProvider(cp, k.cryptoEndpoint)
@@ -294,28 +282,20 @@ func (k *Wrapper) getOciKmsManagementClient(cp common.ConfigurationProvider) (*k
 	return &kmsManagementClient, nil
 }
 
-// Request metadata includes retry policy
+// getRequestMetadata sets a retry policy for 5xx errors with exp backoff.
 func (k *Wrapper) getRequestMetadata() common.RequestMetadata {
-	// Only retry for 5xx errors
 	retryOn5xxFunc := func(r common.OCIOperationResponse) bool {
 		return r.Error != nil && r.Response.HTTPResponse().StatusCode >= 500
 	}
-	return getRequestMetadataWithCustomizedRetryPolicy(retryOn5xxFunc)
-}
 
-func getRequestMetadataWithCustomizedRetryPolicy(fn func(r common.OCIOperationResponse) bool) common.RequestMetadata {
-	rp := getExponentialBackoffRetryPolicy(uint(KMSMaximumNumberOfRetries), fn)
-	return common.RequestMetadata{
-		RetryPolicy: &rp,
-	}
-}
-
-func getExponentialBackoffRetryPolicy(n uint, fn func(r common.OCIOperationResponse) bool) common.RetryPolicy {
-	// The duration between each retry operation, you might want to wait longer each time the retry fails
 	exponentialBackoff := func(r common.OCIOperationResponse) time.Duration {
 		return time.Duration(math.Pow(float64(2), float64(r.AttemptNumber-1))) * time.Second
 	}
-	return common.NewRetryPolicy(n, fn, exponentialBackoff)
+
+	rp := common.NewRetryPolicy(uint(KMSMaximumNumberOfRetries), retryOn5xxFunc, exponentialBackoff)
+	return common.RequestMetadata{
+		RetryPolicy: &rp,
+	}
 }
 
 func (k *Wrapper) getCurrentKeyVersion(ctx context.Context) (string, error) {

--- a/wrappers/ocikms/ocikms.go
+++ b/wrappers/ocikms/ocikms.go
@@ -34,8 +34,14 @@ const (
 )
 
 type Wrapper struct {
-	authTypeAPIKey bool   // true for user principal, false for instance principal, default is false
-	keyId          string // OCI KMS keyId
+	authTypeAPIKey       bool   // true for user principal, false for instance principal, default is false
+	keyId                string // OCI KMS keyId
+	tenancyOCID          string
+	userOCID             string
+	keyFingerprint       string
+	region               string
+	privateKey           string
+	privateKeyPassphrase string
 
 	cryptoEndpoint     string // OCI KMS crypto endpoint
 	managementEndpoint string // OCI KMS management endpoint
@@ -57,7 +63,7 @@ func NewWrapper() *Wrapper {
 	return k
 }
 
-func (k *Wrapper) SetConfig(_ context.Context, opt ...wrapping.Option) (*wrapping.WrapperConfig, error) {
+func (k *Wrapper) SetConfig(ctx context.Context, opt ...wrapping.Option) (*wrapping.WrapperConfig, error) {
 	opts, err := getOpts(opt...)
 	if err != nil {
 		return nil, err
@@ -65,61 +71,72 @@ func (k *Wrapper) SetConfig(_ context.Context, opt ...wrapping.Option) (*wrappin
 
 	// Check and set KeyId
 	switch {
-	case os.Getenv(EnvOciKmsWrapperKeyId) != "" && !opts.Options.WithDisallowEnvVars:
+	case !opts.Options.WithDisallowEnvVars && os.Getenv(EnvOciKmsWrapperKeyId) != "":
 		k.keyId = os.Getenv(EnvOciKmsWrapperKeyId)
-	case os.Getenv(EnvVaultOciKmsSealKeyId) != "" && !opts.Options.WithDisallowEnvVars:
+	case !opts.Options.WithDisallowEnvVars && os.Getenv(EnvVaultOciKmsSealKeyId) != "":
 		k.keyId = os.Getenv(EnvVaultOciKmsSealKeyId)
 	case opts.WithKeyId != "":
 		k.keyId = opts.WithKeyId
 	default:
-		return nil, fmt.Errorf("'%s' not found for OCI KMS seal configuration", KmsConfigKeyId)
+		return nil, fmt.Errorf("%q not found for OCI KMS seal configuration", KmsConfigKeyId)
 	}
 	// Check and set cryptoEndpoint
 	switch {
-	case os.Getenv(EnvOciKmsWrapperCryptoEndpoint) != "" && !opts.Options.WithDisallowEnvVars:
+	case !opts.Options.WithDisallowEnvVars && os.Getenv(EnvOciKmsWrapperCryptoEndpoint) != "":
 		k.cryptoEndpoint = os.Getenv(EnvOciKmsWrapperCryptoEndpoint)
-	case os.Getenv(EnvVaultOciKmsSealCryptoEndpoint) != "" && !opts.Options.WithDisallowEnvVars:
+	case !opts.Options.WithDisallowEnvVars && os.Getenv(EnvVaultOciKmsSealCryptoEndpoint) != "":
 		k.cryptoEndpoint = os.Getenv(EnvVaultOciKmsSealCryptoEndpoint)
 	case opts.withCryptoEndpoint != "":
 		k.cryptoEndpoint = opts.withCryptoEndpoint
 	default:
-		return nil, fmt.Errorf("'%s' not found for OCI KMS seal configuration", KmsConfigCryptoEndpoint)
+		return nil, fmt.Errorf("%q not found for OCI KMS seal configuration", KmsConfigCryptoEndpoint)
 	}
 
 	// Check and set managementEndpoint
 	switch {
-	case os.Getenv(EnvOciKmsWrapperManagementEndpoint) != "" && !opts.Options.WithDisallowEnvVars:
+	case !opts.Options.WithDisallowEnvVars && os.Getenv(EnvOciKmsWrapperManagementEndpoint) != "":
 		k.managementEndpoint = os.Getenv(EnvOciKmsWrapperManagementEndpoint)
-	case os.Getenv(EnvVaultOciKmsSealManagementEndpoint) != "" && !opts.Options.WithDisallowEnvVars:
+	case !opts.Options.WithDisallowEnvVars && os.Getenv(EnvVaultOciKmsSealManagementEndpoint) != "":
 		k.managementEndpoint = os.Getenv(EnvVaultOciKmsSealManagementEndpoint)
 	case opts.withManagementEndpoint != "":
 		k.managementEndpoint = opts.withManagementEndpoint
 	default:
-		return nil, fmt.Errorf("'%s' not found for OCI KMS seal configuration", KmsConfigManagementEndpoint)
+		return nil, fmt.Errorf("%q not found for OCI KMS seal configuration", KmsConfigManagementEndpoint)
 	}
 
 	k.authTypeAPIKey = opts.withAuthTypeApiKey
+	k.tenancyOCID = opts.withTenancyOCID
+	k.userOCID = opts.withUserOCID
+	k.keyFingerprint = opts.withKeyFingerprint
+	k.region = opts.withRegion
+	k.privateKey = opts.withPrivateKey
+	k.privateKeyPassphrase = opts.WithPrivateKeyPassphrase
+
+	cp, err := k.getConfigProvider(opts.Options.WithDisallowEnvVars)
+	if err != nil {
+		return nil, fmt.Errorf("failed creating configuration provider: %w", err)
+	}
 
 	// Check and set OCI KMS crypto client
 	if k.cryptoClient == nil {
-		kmsCryptoClient, err := k.getOciKmsCryptoClient()
+		kmsCryptoClient, err := k.getOciKmsCryptoClient(cp)
 		if err != nil {
-			return nil, fmt.Errorf("error initializing OCI KMS client: %w", err)
+			return nil, fmt.Errorf("error initializing OCI KMS crypto client: %w", err)
 		}
 		k.cryptoClient = kmsCryptoClient
 	}
 
 	// Check and set OCI KMS management client
 	if k.managementClient == nil {
-		kmsManagementClient, err := k.getOciKmsManagementClient()
+		kmsManagementClient, err := k.getOciKmsManagementClient(cp)
 		if err != nil {
-			return nil, fmt.Errorf("error initializing OCI KMS client: %w", err)
+			return nil, fmt.Errorf("error initializing OCI KMS management client: %w", err)
 		}
 		k.managementClient = kmsManagementClient
 	}
 
 	// Calling Encrypt method with empty string just to validate keyId access and store current keyVersion
-	encryptedBlobInfo, err := k.Encrypt(context.Background(), []byte(""), nil)
+	encryptedBlobInfo, err := k.Encrypt(ctx, []byte(""), nil)
 	if err != nil || encryptedBlobInfo == nil {
 		return nil, fmt.Errorf("failed "+KmsConfigKeyId+" validation: %w", err)
 	}
@@ -182,7 +199,7 @@ func (k *Wrapper) Encrypt(ctx context.Context, plaintext []byte, opt ...wrapping
 
 	// Note: It is potential a timing issue if the key gets rotated between this
 	// getCurrentKeyVersion operation and above Encrypt operation
-	keyVersion, err := k.getCurrentKeyVersion()
+	keyVersion, err := k.getCurrentKeyVersion(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error getting current key version: %w", err)
 	}
@@ -239,11 +256,15 @@ func (k *Wrapper) Decrypt(ctx context.Context, in *wrapping.BlobInfo, opt ...wra
 	return plaintext, nil
 }
 
-func (k *Wrapper) getConfigProvider() (common.ConfigurationProvider, error) {
+func (k *Wrapper) getConfigProvider(withDisallowEnvVars bool) (common.ConfigurationProvider, error) {
 	var cp common.ConfigurationProvider
 	var err error
 	if k.authTypeAPIKey {
-		cp = common.DefaultConfigProvider()
+		if !withDisallowEnvVars {
+			cp = common.DefaultConfigProvider()
+		} else {
+			cp = common.NewRawConfigurationProvider(k.tenancyOCID, k.userOCID, k.region, k.keyFingerprint, k.privateKey, &k.privateKeyPassphrase)
+		}
 	} else {
 		cp, err = auth.InstancePrincipalConfigurationProvider()
 		if err != nil {
@@ -254,13 +275,7 @@ func (k *Wrapper) getConfigProvider() (common.ConfigurationProvider, error) {
 }
 
 // Build OCI KMS crypto client
-func (k *Wrapper) getOciKmsCryptoClient() (*keymanagement.KmsCryptoClient, error) {
-	cp, err := k.getConfigProvider()
-	if err != nil {
-		return nil, fmt.Errorf("failed creating configuration provider: %w", err)
-	}
-
-	// Build crypto client
+func (k *Wrapper) getOciKmsCryptoClient(cp common.ConfigurationProvider) (*keymanagement.KmsCryptoClient, error) {
 	kmsCryptoClient, err := keymanagement.NewKmsCryptoClientWithConfigurationProvider(cp, k.cryptoEndpoint)
 	if err != nil {
 		return nil, fmt.Errorf("failed creating NewKmsCryptoClientWithConfigurationProvider: %w", err)
@@ -270,16 +285,10 @@ func (k *Wrapper) getOciKmsCryptoClient() (*keymanagement.KmsCryptoClient, error
 }
 
 // Build OCI KMS management client
-func (k *Wrapper) getOciKmsManagementClient() (*keymanagement.KmsManagementClient, error) {
-	cp, err := k.getConfigProvider()
-	if err != nil {
-		return nil, fmt.Errorf("failed creating configuration provider: %w", err)
-	}
-
-	// Build crypto client
+func (k *Wrapper) getOciKmsManagementClient(cp common.ConfigurationProvider) (*keymanagement.KmsManagementClient, error) {
 	kmsManagementClient, err := keymanagement.NewKmsManagementClientWithConfigurationProvider(cp, k.managementEndpoint)
 	if err != nil {
-		return nil, fmt.Errorf("failed creating NewKmsCryptoClientWithConfigurationProvider: %w", err)
+		return nil, fmt.Errorf("failed creating NewKmsManagementClientWithConfigurationProvider: %w", err)
 	}
 
 	return &kmsManagementClient, nil
@@ -295,21 +304,21 @@ func (k *Wrapper) getRequestMetadata() common.RequestMetadata {
 }
 
 func getRequestMetadataWithCustomizedRetryPolicy(fn func(r common.OCIOperationResponse) bool) common.RequestMetadata {
+	rp := getExponentialBackoffRetryPolicy(uint(KMSMaximumNumberOfRetries), fn)
 	return common.RequestMetadata{
-		RetryPolicy: getExponentialBackoffRetryPolicy(uint(KMSMaximumNumberOfRetries), fn),
+		RetryPolicy: &rp,
 	}
 }
 
-func getExponentialBackoffRetryPolicy(n uint, fn func(r common.OCIOperationResponse) bool) *common.RetryPolicy {
+func getExponentialBackoffRetryPolicy(n uint, fn func(r common.OCIOperationResponse) bool) common.RetryPolicy {
 	// The duration between each retry operation, you might want to wait longer each time the retry fails
 	exponentialBackoff := func(r common.OCIOperationResponse) time.Duration {
 		return time.Duration(math.Pow(float64(2), float64(r.AttemptNumber-1))) * time.Second
 	}
-	policy := common.NewRetryPolicy(n, fn, exponentialBackoff)
-	return &policy
+	return common.NewRetryPolicy(n, fn, exponentialBackoff)
 }
 
-func (k *Wrapper) getCurrentKeyVersion() (string, error) {
+func (k *Wrapper) getCurrentKeyVersion(ctx context.Context) (string, error) {
 	if k.managementClient == nil {
 		return "", fmt.Errorf("managementClient has not yet initialized")
 	}
@@ -318,7 +327,7 @@ func (k *Wrapper) getCurrentKeyVersion() (string, error) {
 		KeyId:           &k.keyId,
 		RequestMetadata: requestMetadata,
 	}
-	getKeyResponse, err := k.managementClient.GetKey(context.Background(), getKeyInput)
+	getKeyResponse, err := k.managementClient.GetKey(ctx, getKeyInput)
 	if err != nil || getKeyResponse.CurrentKeyVersion == nil {
 		return "", fmt.Errorf("failed getting current key version: %w", err)
 	}

--- a/wrappers/ocikms/options.go
+++ b/wrappers/ocikms/options.go
@@ -86,7 +86,7 @@ func getOpts(opt ...wrapping.Option) (*options, error) {
 			case KmsConfigPrivateKey:
 				opts.withPrivateKey = v
 			case KmsConfigPrivateKeyPassphrase:
-				opts.WithPrivateKeyPassphrase = v
+				opts.withPrivateKeyPassphrase = v
 			case KmsConfigAuthTypeApiKey:
 				var err error
 				opts.withAuthTypeApiKey, err = strconv.ParseBool(v)
@@ -129,5 +129,5 @@ type options struct {
 	withKeyFingerprint       string
 	withRegion               string
 	withPrivateKey           string
-	WithPrivateKeyPassphrase string
+	withPrivateKeyPassphrase string
 }

--- a/wrappers/ocikms/options.go
+++ b/wrappers/ocikms/options.go
@@ -19,7 +19,18 @@ const (
 	KmsConfigManagementEndpoint = "management_endpoint"
 	// authTypeApiKey config
 	KmsConfigAuthTypeApiKey = "auth_type_api_key"
+
+	KmsConfigTenancyOCID          = "tenancy_ocid"
+	KmsConfigUserOCID             = "user_ocid"
+	KmsConfigKeyFingerprint       = "fingerprint"
+	KmsConfigRegion               = "region"
+	KmsConfigPrivateKey           = "private_key"
+	KmsConfigPrivateKeyPassphrase = "private_key_passphrase"
 )
+
+func getDefaultOptions() options {
+	return options{}
+}
 
 // getOpts iterates the inbound Options and returns a struct
 func getOpts(opt ...wrapping.Option) (*options, error) {
@@ -64,6 +75,18 @@ func getOpts(opt ...wrapping.Option) (*options, error) {
 				opts.withCryptoEndpoint = v
 			case KmsConfigManagementEndpoint:
 				opts.withManagementEndpoint = v
+			case KmsConfigTenancyOCID:
+				opts.withTenancyOCID = v
+			case KmsConfigUserOCID:
+				opts.withUserOCID = v
+			case KmsConfigKeyFingerprint:
+				opts.withKeyFingerprint = v
+			case KmsConfigRegion:
+				opts.withRegion = v
+			case KmsConfigPrivateKey:
+				opts.withPrivateKey = v
+			case KmsConfigPrivateKeyPassphrase:
+				opts.WithPrivateKeyPassphrase = v
 			case KmsConfigAuthTypeApiKey:
 				var err error
 				opts.withAuthTypeApiKey, err = strconv.ParseBool(v)
@@ -98,41 +121,13 @@ type OptionFunc func(*options) error
 type options struct {
 	*wrapping.Options
 
-	withCryptoEndpoint     string
-	withManagementEndpoint string
-	withAuthTypeApiKey     bool
-}
-
-func getDefaultOptions() options {
-	return options{}
-}
-
-// WithCryptoEndpoint provides a way to chose the endpoint
-func WithCryptoEndpoint(with string) wrapping.Option {
-	return func() interface{} {
-		return OptionFunc(func(o *options) error {
-			o.withCryptoEndpoint = with
-			return nil
-		})
-	}
-}
-
-// WithManagementEndpoint provides a way to chose the management endpoint
-func WithManagementEndpoint(with string) wrapping.Option {
-	return func() interface{} {
-		return OptionFunc(func(o *options) error {
-			o.withManagementEndpoint = with
-			return nil
-		})
-	}
-}
-
-// WithAuthTypeApiKey provides a way to say to use api keys for auth
-func WithAuthTypeApiKey(with bool) wrapping.Option {
-	return func() interface{} {
-		return OptionFunc(func(o *options) error {
-			o.withAuthTypeApiKey = with
-			return nil
-		})
-	}
+	withCryptoEndpoint       string
+	withManagementEndpoint   string
+	withAuthTypeApiKey       bool
+	withTenancyOCID          string
+	withUserOCID             string
+	withKeyFingerprint       string
+	withRegion               string
+	withPrivateKey           string
+	WithPrivateKeyPassphrase string
 }


### PR DESCRIPTION
As a part of #110 this PR enforces that no env nor file-based reads are conducted while `WithDisallowEnvVars` was provided as a wrapper option for `OCIKMS` wrapper.