### PR TITLE
Pin to OpenBao v2.5.5 container image

### DIFF
--- a/kms/transit/transit_test.go
+++ b/kms/transit/transit_test.go
@@ -314,6 +314,7 @@ func setupTransitEngine(t *testing.T) (*docker.DockerCluster, *api.Client) {
 	opts.NumCores = 1
 	opts.Storage = inmemStorage{}
 	opts.HADisabled = true
+	opts.ImageTag = "2.5.5"
 	cluster := docker.NewTestDockerCluster(t, opts)
 
 	client := cluster.ClusterNodes[0].APIClient()

--- a/wrappers/transit/transit_test.go
+++ b/wrappers/transit/transit_test.go
@@ -65,6 +65,7 @@ func (m *testTransitClient) Decrypt(ctx context.Context, ciphertext []byte) ([]b
 func getTestCluster(t *testing.T) (*docker.DockerCluster, *docker.DockerClusterNode, *api.Client) {
 	opts := docker.DefaultOptions(t)
 	opts.ClusterOptions.NumCores = 1
+	opts.ImageTag = "2.5.5"
 	cluster := docker.NewTestDockerCluster(t, opts)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)


### PR DESCRIPTION
Setting root=true ensures that we can work with both pre-2.6.0 Alpine containers and older containers.

See also: https://github.com/openbao/openbao/pull/3499