### PR TITLE
Ensure no uncontrolled env or file reads within Transit wrapper

### DIFF
--- a/wrappers/transit/options.go
+++ b/wrappers/transit/options.go
@@ -59,11 +59,17 @@ func getOpts(opt ...wrapping.Option) (*options, error) {
 			case "tls_ca_cert":
 				opts.withTlsCaCert = v
 			case "tls_ca_path":
-				opts.withTlsCaPath = v
+				opts.withTlsCaCertDir = v
 			case "tls_client_cert":
 				opts.withTlsClientCert = v
 			case "tls_client_key":
 				opts.withTlsClientKey = v
+			case "tls_ca_cert_bytes":
+				opts.withTlsCaCertBytes = v
+			case "tls_client_cert_bytes":
+				opts.withTlsClientCertBytes = v
+			case "tls_client_key_bytes":
+				opts.withTlsClientKeyBytes = v
 			case "tls_server_name":
 				opts.withTlsServerName = v
 			case "tls_skip_verify":
@@ -104,19 +110,22 @@ type OptionFunc func(*options) error
 type options struct {
 	*wrapping.Options
 
-	withMountPath      string
-	withKeyName        string
-	withDisableRenewal string
-	withNamespace      string
-	withAddress        string
-	withTlsCaCert      string
-	withTlsCaPath      string
-	withTlsClientCert  string
-	withTlsClientKey   string
-	withTlsServerName  string
-	withTlsSkipVerify  bool
-	withToken          string
-	withKeyIdPrefix    string
+	withMountPath          string
+	withKeyName            string
+	withDisableRenewal     string
+	withNamespace          string
+	withAddress            string
+	withTlsCaCert          string
+	withTlsCaCertDir       string
+	withTlsClientCert      string
+	withTlsClientKey       string
+	withTlsCaCertBytes     string
+	withTlsClientCertBytes string
+	withTlsClientKeyBytes  string
+	withTlsServerName      string
+	withTlsSkipVerify      bool
+	withToken              string
+	withKeyIdPrefix        string
 }
 
 func getDefaultOptions() options {
@@ -183,11 +192,11 @@ func WithTlsCaCert(with string) wrapping.Option {
 	}
 }
 
-// WithTlsCaPath provides a way to choose the CA path
-func WithTlsCaPath(with string) wrapping.Option {
+// WithTlsCaDir provides a way to choose the CA directory path
+func WithTlsCaDir(with string) wrapping.Option {
 	return func() interface{} {
 		return OptionFunc(func(o *options) error {
-			o.withTlsCaPath = with
+			o.withTlsCaCertDir = with
 			return nil
 		})
 	}

--- a/wrappers/transit/options_test.go
+++ b/wrappers/transit/options_test.go
@@ -116,13 +116,13 @@ func Test_GetOpts(t *testing.T) {
 		require.NoError(err)
 		testOpts, err := getOpts()
 		require.NoError(err)
-		testOpts.withTlsCaPath = ""
+		testOpts.withTlsCaCertDir = ""
 		assert.Equal(opts, testOpts)
 
 		const with = "test"
-		opts, err = getOpts(WithTlsCaPath(with))
+		opts, err = getOpts(WithTlsCaDir(with))
 		require.NoError(err)
-		testOpts.withTlsCaPath = with
+		testOpts.withTlsCaCertDir = with
 		assert.Equal(opts, testOpts)
 	})
 	t.Run("WithTlsClientCert", func(t *testing.T) {

--- a/wrappers/transit/transit_client.go
+++ b/wrappers/transit/transit_client.go
@@ -118,25 +118,43 @@ func newTransitClient(logger hclog.Logger, opts *options) (*TransitClient, *wrap
 		token = opts.withToken
 	}
 
-	apiConfig := api.DefaultConfig()
+	var apiConfig *api.Config
+	if !opts.Options.WithDisallowEnvVars {
+		apiConfig = api.DefaultConfig()
+	} else {
+		apiConfig = api.NewConfig()
+		apiConfig.Address = "https://127.0.0.1:8200"
+	}
+
 	if address != "" {
 		apiConfig.Address = address
 	}
-	if opts.withTlsCaCert != "" ||
-		opts.withTlsCaPath != "" ||
-		opts.withTlsClientCert != "" ||
-		opts.withTlsClientKey != "" ||
-		opts.withTlsServerName != "" ||
-		opts.withTlsSkipVerify {
 
-		tlsConfig := &api.TLSConfig{
-			CACert:        opts.withTlsCaCert,
-			CAPath:        opts.withTlsCaPath,
-			ClientCert:    opts.withTlsClientCert,
-			ClientKey:     opts.withTlsClientKey,
-			TLSServerName: opts.withTlsServerName,
-			Insecure:      opts.withTlsSkipVerify,
+	tlsConfig := &api.TLSConfig{
+		TLSServerName: opts.withTlsServerName,
+		Insecure:      opts.withTlsSkipVerify,
+	}
+
+	hasTLSCaConfig := opts.withTlsCaCert != "" || opts.withTlsCaCertDir != "" || opts.withTlsCaCertBytes != ""
+	if hasTLSCaConfig {
+		if !opts.Options.WithDisallowEnvVars {
+			tlsConfig.CACert = opts.withTlsCaCert
+			tlsConfig.CAPath = opts.withTlsCaCertDir
 		}
+		tlsConfig.CACertBytes = []byte(opts.withTlsCaCertBytes)
+	}
+
+	hasTLSConfig := (opts.withTlsClientCert != "" && opts.withTlsClientKey != "") || (opts.withTlsClientCertBytes != "" && opts.withTlsClientKeyBytes != "")
+	if hasTLSConfig {
+		if !opts.Options.WithDisallowEnvVars {
+			tlsConfig.ClientCert = opts.withTlsClientCert
+			tlsConfig.ClientKey = opts.withTlsClientKey
+		}
+		tlsConfig.ClientCertBytes = []byte(opts.withTlsClientCertBytes)
+		tlsConfig.ClientKeyBytes = []byte(opts.withTlsClientKeyBytes)
+	}
+
+	if tlsConfig.Insecure || tlsConfig.TLSServerName != "" || hasTLSCaConfig || hasTLSConfig {
 		if err := apiConfig.ConfigureTLS(tlsConfig); err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
As a part of #110 this PR enforces that no env nor file-based reads are conducted while `WithDisallowEnvVars` was provided as a wrapper option for `Transit` wrapper.