### PR TITLE
Set ErrorUnused=true for kms.ConfigMap decoding

### DIFF
--- a/kms/kms.go
+++ b/kms/kms.go
@@ -120,10 +120,12 @@ type Key interface {
 // ConfigMap represents user-defined data that is used to configure APIs in this
 // package via provider-specific parameters.
 //
-// A ConfigMap MUST use JSON-serializable types only. Providers are expected
-// to decode ConfigMaps using mapstructure.WeakDecode. For a reference
-// implementation, see the github.com/openbao/go-kms-wrapping/v2/kms/transit
-// package.
+// A ConfigMap MUST use JSON-serializable types only. Providers are recommended
+// to decode ConfigMaps using mapstructure's decoder with ErrorUnused=true and
+// WeaklyTypedInput=true set.
+//
+// For a reference implementation of config map decoding via mapstructure, see
+// the github.com/openbao/go-kms-wrapping/v2/kms/transit package.
 type ConfigMap map[string]any
 
 // OpenOptions is passed to [KMS.Open].

--- a/kms/pkcs11/pkcs11.go
+++ b/kms/pkcs11/pkcs11.go
@@ -57,9 +57,19 @@ func (p *pkcs11KMS) Open(ctx context.Context, opts *kms.OpenOptions) error {
 		// Other tweaks.
 		DisableSoftwareEncryption bool `mapstructure:"disable_software_encryption"`
 	}
-	if err := mapstructure.WeakDecode(opts.ConfigMap, &cfg); err != nil {
+
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		Result:           &cfg,
+		ErrorUnused:      true,
+		WeaklyTypedInput: true,
+	})
+	if err != nil {
 		return err
 	}
+	if err := decoder.Decode(opts.ConfigMap); err != nil {
+		return err
+	}
+
 	if cfg.Lib == "" {
 		return errors.New("missing required parameter 'lib'")
 	}
@@ -118,7 +128,16 @@ func (p *pkcs11KMS) GetKey(ctx context.Context, opts *kms.KeyOptions) (kms.Key, 
 		Mechanism   string `mapstructure:"mechanism"`
 		RSAOAEPHash string `mapstructure:"rsa_oaep_hash"`
 	}
-	if err := mapstructure.WeakDecode(opts.ConfigMap, &cfg); err != nil {
+
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		Result:           &cfg,
+		ErrorUnused:      true,
+		WeaklyTypedInput: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := decoder.Decode(opts.ConfigMap); err != nil {
 		return nil, err
 	}
 

--- a/kms/transit/transit.go
+++ b/kms/transit/transit.go
@@ -57,7 +57,15 @@ func (k *transitKMS) Open(ctx context.Context, opts *kms.OpenOptions) error {
 		TLSClientKeyBytes  string `mapstructure:"tls_client_key_bytes"`
 	}
 
-	if err := mapstructure.WeakDecode(opts.ConfigMap, &cfg); err != nil {
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		Result:           &cfg,
+		ErrorUnused:      true,
+		WeaklyTypedInput: true,
+	})
+	if err != nil {
+		return err
+	}
+	if err := decoder.Decode(opts.ConfigMap); err != nil {
 		return err
 	}
 
@@ -158,9 +166,19 @@ func (k *transitKMS) GetKey(_ context.Context, opts *kms.KeyOptions) (kms.Key, e
 		Name              string `mapstructure:"name"`
 		DisablePrehashing bool   `mapstructure:"disable_prehashing"`
 	}
-	if err := mapstructure.WeakDecode(opts.ConfigMap, &cfg); err != nil {
+
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		Result:           &cfg,
+		ErrorUnused:      true,
+		WeaklyTypedInput: true,
+	})
+	if err != nil {
 		return nil, err
 	}
+	if err := decoder.Decode(opts.ConfigMap); err != nil {
+		return nil, err
+	}
+
 	if cfg.Name == "" {
 		return nil, errors.New("missing required parameter 'name'")
 	}


### PR DESCRIPTION
While a wrapper's `WithConfigMap` is tolerant w.r.t. unused keys (IMO a historical mistake, probably not even a bad idea to change it), let's avoid it out of the box when it comes to KMSes. This will save users from typos; finding out that a critical cryptographic option wasn't applied after the fact because the config key went into the void seems not great.