### PR TITLE
Add aliases to kms/pkcs11

### DIFF
--- a/kms/pkcs11/pkcs11.go
+++ b/kms/pkcs11/pkcs11.go
@@ -28,6 +28,12 @@ func New() kms.KMS {
 	return &pkcs11KMS{}
 }
 
+// NewWithAliases returns a new KMS that uses PKCS#11 libraries and provides it
+// with a map of library path aliases.
+func NewWithAliases(aliases map[string]string) kms.KMS {
+	return &pkcs11KMS{aliases: aliases}
+}
+
 // pkcs11KMS implements kms.KMS.
 type pkcs11KMS struct {
 	kms.UnimplementedKMS
@@ -39,6 +45,13 @@ type pkcs11KMS struct {
 	// Disable preferring local public key encryption over performing public key
 	// encryption via PKCS#11.
 	disableSoftwareEncryption bool
+
+	// aliases map a name (an alias) to a library path. If the KMS is
+	// opened with AllowEnvironment=false, libraries may only be opened via
+	// alias, i.e., the "lib" parameter is always interpreted as one. If
+	// AllowEnvironment=true, aliases take precedence, but "lib" may still be a
+	// plain file path.
+	aliases map[string]string
 }
 
 func (p *pkcs11KMS) Open(ctx context.Context, opts *kms.OpenOptions) error {
@@ -89,8 +102,18 @@ func (p *pkcs11KMS) Open(ctx context.Context, opts *kms.OpenOptions) error {
 		return errors.New("at least one of 'slot', 'serial', 'token' is required")
 	}
 
+	// Resolve library aliases and fall back to plain path if allowed.
+	lib, ok := p.aliases[cfg.Lib]
+	if !ok {
+		if opts.AllowEnvironment {
+			lib = cfg.Lib
+		} else {
+			return fmt.Errorf("unknown library alias: %q", cfg.Lib)
+		}
+	}
+
 	// Open the library:
-	mod, err := module.Open(cfg.Lib)
+	mod, err := module.Open(lib)
 	if err != nil {
 		return err
 	}

--- a/kms/pkcs11/pkcs11_test.go
+++ b/kms/pkcs11/pkcs11_test.go
@@ -35,7 +35,8 @@ func NewTestKMS(t *testing.T, configs ...kms.ConfigMap) *pkcs11KMS {
 	}
 
 	require.NoError(t, svc.Open(t.Context(), &kms.OpenOptions{
-		ConfigMap: config,
+		ConfigMap:        config,
+		AllowEnvironment: true,
 	}))
 	t.Cleanup(func() {
 		require.NoError(t, svc.Close(context.Background()))
@@ -78,14 +79,69 @@ func TestOpen(t *testing.T) {
 	for i, config := range good {
 		t.Run(fmt.Sprintf("good[%d]", i), func(t *testing.T) {
 			svc := New()
-			require.NoError(t, svc.Open(ctx, &kms.OpenOptions{ConfigMap: config}))
+			require.NoError(t, svc.Open(ctx, &kms.OpenOptions{
+				ConfigMap:        config,
+				AllowEnvironment: true,
+			}))
 			require.NoError(t, svc.Close(ctx))
 		})
 	}
 
 	for i, config := range bad {
 		t.Run(fmt.Sprintf("bad[%d]", i), func(t *testing.T) {
-			require.Error(t, New().Open(ctx, &kms.OpenOptions{ConfigMap: config}))
+			require.Error(t, New().Open(ctx, &kms.OpenOptions{
+				ConfigMap:        config,
+				AllowEnvironment: true,
+			}))
+		})
+	}
+}
+
+func TestAliases(t *testing.T) {
+	ctx := t.Context()
+
+	lib, token, pin := testvars.Vars(t)
+	aliases := map[string]string{"foo": lib}
+
+	tests := []struct {
+		lib string
+		env bool
+		err bool
+	}{
+		{
+			lib: "foo",
+		},
+		{
+			lib: "foo",
+			env: true,
+		},
+		{
+			lib: lib,
+			env: true,
+		},
+		{
+			lib: lib,
+			err: true,
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			svc := NewWithAliases(aliases)
+			err := svc.Open(ctx, &kms.OpenOptions{
+				AllowEnvironment: tt.env,
+				ConfigMap: kms.ConfigMap{
+					"lib":         tt.lib,
+					"pin":         pin,
+					"token_label": token,
+				},
+			})
+			if tt.err {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.NoError(t, svc.Close(ctx))
+			}
 		})
 	}
 }


### PR DESCRIPTION
Add a `NewWithAliases` constructor to the PKCS#11 KMS that can be used by the PKCS#11 plugin entrypoint to provide a set of library aliases before `Open()` is ever called by the application.

Related: https://github.com/openbao/go-kms-wrapping/issues/110
Related: https://github.com/openbao/openbao/issues/3338
