### PR TITLE
Forbid path parsing with env reading while `withDisallowEnvVars` flag if provided

### DIFF
--- a/wrappers/alicloudkms/options.go
+++ b/wrappers/alicloudkms/options.go
@@ -70,8 +70,10 @@ func getOpts(opt ...wrapping.Option) (*options, error) {
 		}
 	}
 
-	if err := wrapping.ParsePaths(&opts.withAccessSecret, &opts.withSecretKey, &opts.withAccessKey); err != nil {
-		return nil, err
+	if !opts.WithDisallowEnvVars {
+		if err := wrapping.ParsePaths(&opts.withAccessSecret, &opts.withSecretKey, &opts.withAccessKey); err != nil {
+			return nil, err
+		}
 	}
 
 	return &opts, nil

--- a/wrappers/awskms/options.go
+++ b/wrappers/awskms/options.go
@@ -88,8 +88,10 @@ func getOpts(opt ...wrapping.Option) (*options, error) {
 		}
 	}
 
-	if err := wrapping.ParsePaths(&opts.withAccessKey, &opts.withSecretKey, &opts.withSessionToken); err != nil {
-		return nil, err
+	if !opts.WithDisallowEnvVars {
+		if err := wrapping.ParsePaths(&opts.withAccessKey, &opts.withSecretKey, &opts.withSessionToken); err != nil {
+			return nil, err
+		}
 	}
 
 	return &opts, nil

--- a/wrappers/azurekeyvault/options.go
+++ b/wrappers/azurekeyvault/options.go
@@ -90,8 +90,10 @@ func getOpts(opt ...wrapping.Option) (*options, error) {
 		}
 	}
 
-	if err := wrapping.ParsePaths(&opts.withClientId, &opts.withClientSecret, &opts.withTenantId); err != nil {
-		return nil, err
+	if !opts.WithDisallowEnvVars {
+		if err := wrapping.ParsePaths(&opts.withClientId, &opts.withClientSecret, &opts.withTenantId); err != nil {
+			return nil, err
+		}
 	}
 
 	return &opts, nil

--- a/wrappers/gcpckms/options.go
+++ b/wrappers/gcpckms/options.go
@@ -78,8 +78,10 @@ func getOpts(opt ...wrapping.Option) (*options, error) {
 		}
 	}
 
-	if err := wrapping.ParsePaths(&opts.withCredentials); err != nil {
-		return nil, err
+	if !opts.WithDisallowEnvVars {
+		if err := wrapping.ParsePaths(&opts.withCredentials); err != nil {
+			return nil, err
+		}
 	}
 
 	return &opts, nil

--- a/wrappers/huaweicloudkms/options.go
+++ b/wrappers/huaweicloudkms/options.go
@@ -70,8 +70,10 @@ func getOpts(opt ...wrapping.Option) (*options, error) {
 		}
 	}
 
-	if err := wrapping.ParsePaths(&opts.withSecretKey, &opts.withAccessKey); err != nil {
-		return nil, err
+	if !opts.WithDisallowEnvVars {
+		if err := wrapping.ParsePaths(&opts.withSecretKey, &opts.withAccessKey); err != nil {
+			return nil, err
+		}
 	}
 
 	return &opts, nil

--- a/wrappers/ocikms/options.go
+++ b/wrappers/ocikms/options.go
@@ -107,8 +107,10 @@ func getOpts(opt ...wrapping.Option) (*options, error) {
 		}
 	}
 
-	if err := wrapping.ParsePaths(&opts.WithKeyId); err != nil {
-		return nil, err
+	if !opts.WithDisallowEnvVars {
+		if err := wrapping.ParsePaths(&opts.WithKeyId); err != nil {
+			return nil, err
+		}
 	}
 
 	return &opts, nil

--- a/wrappers/pkcs11/options.go
+++ b/wrappers/pkcs11/options.go
@@ -78,8 +78,10 @@ func getOpts(opt ...wrapping.Option) (*options, error) {
 		}
 	}
 
-	if err := wrapping.ParsePaths(&opts.withPin); err != nil {
-		return nil, err
+	if !opts.WithDisallowEnvVars {
+		if err := wrapping.ParsePaths(&opts.withPin); err != nil {
+			return nil, err
+		}
 	}
 
 	return &opts, nil

--- a/wrappers/static/options.go
+++ b/wrappers/static/options.go
@@ -67,8 +67,10 @@ func getOpts(opt ...wrapping.Option) (*options, error) {
 		}
 	}
 
-	if err := wrapping.ParsePaths(&opts.withPreviousKey, &opts.withCurrentKey); err != nil {
-		return nil, err
+	if !opts.WithDisallowEnvVars {
+		if err := wrapping.ParsePaths(&opts.withPreviousKey, &opts.withCurrentKey); err != nil {
+			return nil, err
+		}
 	}
 
 	return &opts, nil

--- a/wrappers/tencentcloudkms/options.go
+++ b/wrappers/tencentcloudkms/options.go
@@ -68,8 +68,10 @@ func getOpts(opt ...wrapping.Option) (*options, error) {
 		}
 	}
 
-	if err := wrapping.ParsePaths(&opts.withSecretKey, &opts.withAccessKey, &opts.withSessionToken); err != nil {
-		return nil, err
+	if !opts.WithDisallowEnvVars {
+		if err := wrapping.ParsePaths(&opts.withSecretKey, &opts.withAccessKey, &opts.withSessionToken); err != nil {
+			return nil, err
+		}
 	}
 
 	return &opts, nil

--- a/wrappers/transit/options.go
+++ b/wrappers/transit/options.go
@@ -96,8 +96,10 @@ func getOpts(opt ...wrapping.Option) (*options, error) {
 		}
 	}
 
-	if err := wrapping.ParsePaths(&opts.withToken, &opts.withTlsClientKey); err != nil {
-		return nil, err
+	if !opts.WithDisallowEnvVars {
+		if err := wrapping.ParsePaths(&opts.withToken, &opts.withTlsClientKey); err != nil {
+			return nil, err
+		}
 	}
 
 	return &opts, nil


### PR DESCRIPTION
Allows for `ParsePath()` invocation only if the `opts.withDisallowEnvVars` flag wasn't provided to ensure no uncontrolled env/file reads are conducted while setting up a KMS wrapper. Same change introduced to all wrappers.