### PR TITLE
Guard against nil SignerOpts in Transit

### DIFF
--- a/kms/transit/transit.go
+++ b/kms/transit/transit.go
@@ -264,6 +264,10 @@ var hash2transit = map[crypto.Hash]string{
 
 // See: https://openbao.org/api-docs/secret/transit/#sign-data
 func (k *transitKey) Sign(ctx context.Context, opts *kms.SignOptions) ([]byte, error) {
+	if opts.SignerOpts == nil {
+		return nil, errors.New("cannot sign without opts.SignerOpts")
+	}
+
 	hash := opts.HashFunc()
 	if opts.Prehashed && hash != crypto.Hash(0) && k.disablePrehashing {
 		// We are not allowed to pre-hash but got pre-hashed data.
@@ -335,6 +339,10 @@ func (k *transitKey) Sign(ctx context.Context, opts *kms.SignOptions) ([]byte, e
 
 // See: https://openbao.org/api-docs/secret/transit/#verify-signed-data
 func (k *transitKey) Verify(ctx context.Context, opts *kms.VerifyOptions) error {
+	if opts.SignerOpts == nil {
+		return errors.New("cannot verify without opts.SignerOpts")
+	}
+
 	hash := opts.HashFunc()
 	if opts.Prehashed && hash != crypto.Hash(0) && k.disablePrehashing {
 		// We are not allowed to pre-hash but got pre-hashed data.

--- a/kms/transit/transit_test.go
+++ b/kms/transit/transit_test.go
@@ -224,6 +224,25 @@ func test(t *testing.T, k kms.KMS, opts *kms.OpenOptions) {
 			})
 			require.ErrorContains(t, err, ErrPrehashingDisabled.Error())
 		})
+
+		t.Run("missing_opts", func(t *testing.T) {
+			key, err := k.GetKey(ctx, &kms.KeyOptions{
+				ConfigMap: kms.ConfigMap{
+					"name":               "ecdsa-p256",
+					"disable_prehashing": true,
+				},
+			})
+			require.NoError(t, err)
+
+			opts := &kms.SignOptions{
+				Data:      []byte{0x00},
+				Prehashed: true,
+			}
+
+			_, err = key.Sign(ctx, opts)
+			require.ErrorContains(t, err, "without opts.SignerOpts")
+		})
+
 	})
 
 	t.Run("ExportPublic", func(t *testing.T) {


### PR DESCRIPTION
This causes a non-recoverable panic in the KMS layer:

    2026-07-27T18:29:15.563-0500 [INFO]  http: panic serving 127.0.0.1:59418: runtime error: invalid memory address or nil pointer dereference
    goroutine 1343 [running]:
    net/http.(*conn).serve.func1()
    	/usr/local/go/src/net/http/server.go:1907 +0xbd
    panic({0x3de73c0?, 0x75daeb0?})
    	/usr/local/go/src/runtime/panic.go:860 +0x13a
    github.com/openbao/go-kms-wrapping/kms/transit/v2.(*transitKey).Sign(0x5ab664c9d10, {0x49fc7a8, 0x5ab65cbba70}, 0x5ab660cc780)
    	/home/cipherboy/go/pkg/mod/github.com/openbao/go-kms-wrapping/kms/transit/v2@v2.0.0-20260722171919-2a8eddf5719b/transit.go:280 +0x42
    github.com/openbao/openbao/sdk/v2/helper/keysutil.(*Policy).SignWithOptions(0x5ab65b17b80, 0x0?, {0x0, 0x0, 0x0}, {0x5ab66b01620, 0x20, 0x20}, 0x5ab6608ff08)
    	/home/cipherboy/GitHub/cipherboy/openbao/sdk/helper/keysutil/policy.go:1389 +0xf8c
    github.com/openbao/openbao/v2/internal/builtin/logical/transit.(*backend).pathSignWrite(0x5ab66598af0, {0x49fc7a8, 0x5ab65cbba70}, 0x5ab66423a40, 0x5ab65b46ce0)
    	/home/cipherboy/GitHub/cipherboy/openbao/internal/builtin/logical/transit/path_sign_verify.go:438 +0x1585