### PR TITLE
Close gRPC-bridged keys via runtime.AddCleanup

### DIFF
--- a/kms/kms.go
+++ b/kms/kms.go
@@ -108,15 +108,6 @@ type Key interface {
 	//  - *ecdsa.PublicKey for EC keys
 	//  - ed25519.PublicKey for Ed25519 keys
 	ExportPublic(context.Context) (crypto.PublicKey, error)
-
-	// Close terminates this key, rendering further use of it a semantic error.
-	//
-	// KMS providers likely will not need to directly implement this. Rather,
-	// this is useful for plugin clients to free key references on a remote
-	// plugin server.
-	//
-	// Close should return a nil error if not implemented to signify a no-op.
-	Close(context.Context) error
 }
 
 // ConfigMap represents user-defined data that is used to configure APIs in this
@@ -275,10 +266,6 @@ func (UnimplementedKey) Verify(context.Context, *VerifyOptions) error {
 
 func (UnimplementedKey) ExportPublic(context.Context) (crypto.PublicKey, error) {
 	return nil, ErrNotImplemented
-}
-
-func (UnimplementedKey) Close(context.Context) error {
-	return nil
 }
 
 // NewSigner returns a [crypto.Signer]/[crypto.MessageSigner] built on a [Key]

--- a/kms/pkcs11/wrapper.go
+++ b/kms/pkcs11/wrapper.go
@@ -303,11 +303,5 @@ func (w *pkcs11Wrapper) with(ctx context.Context, info *wrapping.KeyInfo, f func
 		return err
 	}
 
-	defer func() {
-		if err := key.Close(ctx); err != nil {
-			w.logger.Warn("failed to close key", "error", err.Error())
-		}
-	}()
-
 	return f(key)
 }

--- a/plugin/kms_client.go
+++ b/plugin/kms_client.go
@@ -11,6 +11,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"runtime"
 
 	"github.com/hashicorp/go-plugin"
 	pb "github.com/openbao/go-kms-wrapping/plugin/v2/pb/kms"
@@ -90,10 +91,16 @@ func (c *gRPCKMSClient) GetKey(ctx context.Context, opts *kms.KeyOptions) (kms.K
 	if err != nil {
 		return nil, c.handleRPCError(err)
 	}
-	return &gRPCKeyClient{
+	key := &gRPCKeyClient{
 		id:  resp.KeyId,
 		kms: c,
-	}, nil
+	}
+	runtime.AddCleanup(key, func(id string) {
+		_, _ = c.client.CloseKey(c.ctx, &pb.CloseKeyRequest{
+			KeyId: id,
+		})
+	}, resp.KeyId)
+	return key, nil
 }
 
 type gRPCKeyClient struct {
@@ -218,11 +225,4 @@ func (c *gRPCKeyClient) ExportPublic(ctx context.Context) (crypto.PublicKey, err
 		return nil, err
 	}
 	return crypto.PublicKey(pub), nil
-}
-
-func (c *gRPCKeyClient) Close(ctx context.Context) error {
-	_, err := c.kms.client.CloseKey(ctx, &pb.CloseKeyRequest{
-		KeyId: c.id,
-	})
-	return c.kms.handleRPCError(err)
 }

--- a/plugin/kms_server.go
+++ b/plugin/kms_server.go
@@ -144,18 +144,8 @@ func (s *gRPCKMSServer) GetKey(ctx context.Context, req *pb.GetKeyRequest) (*pb.
 
 func (s *gRPCKMSServer) CloseKey(ctx context.Context, req *pb.CloseKeyRequest) (*pb.CloseKeyResponse, error) {
 	s.keysLock.Lock()
-	key, ok := s.keys[req.KeyId]
-	if !ok {
-		s.keysLock.Unlock()
-		return nil, status.Error(codes.NotFound, ErrNoInstance.Error())
-	}
-
 	delete(s.keys, req.KeyId)
 	s.keysLock.Unlock()
-
-	if err := key.Close(ctx); err != nil {
-		return nil, s.handleKMSError(err)
-	}
 
 	return &pb.CloseKeyResponse{}, nil
 }


### PR DESCRIPTION
This removes the `Close` hook from `kms.Key` and replaces its usage in the plugin client with `runtime.AddCleanup`, rendering the operation an internal detail of the plugin protocol.

As the original comment on `Close` states:

```go
type Key interface {
	// Close terminates this key, rendering further use of it a semantic error.
	//
	// KMS providers likely will not need to directly implement this. Rather,
	// this is useful for plugin clients to free key references on a remote
	// plugin server.
	//
	// Close should return a nil error if not implemented to signify a no-op.
	Close(context.Context) error
}
```

...using `runtime.AddCleanup` to effectively propagate garbage collection on the client to the server seems like the more natural fit, and simplifies the API.

Note that `kms.KMS`'s `Close` hook is different, we expect to clean up resources beyond simple memory de-allocation here and need to expose it as an API for interface implementers. Overall, this mirrors OpenBao's expectation that `kms.KMS` is expensive and should be cached while `kms.Key` is cheap and disposable.