### PR TITLE
Add kms.NewSignerWithPublicKey API

### DIFF
--- a/kms/kms.go
+++ b/kms/kms.go
@@ -269,13 +269,25 @@ func (UnimplementedKey) ExportPublic(context.Context) (crypto.PublicKey, error) 
 }
 
 // NewSigner returns a [crypto.Signer]/[crypto.MessageSigner] built on a [Key]
-// for compatibility with crypto/x509 and the likes.
+// for compatibility with crypto/x509 and the likes. This exports the public key
+// on construction. If the public key is already known (e.g., it was exported
+// and stored previously), prefer [NewSignerWithPublicKey].
 func NewSigner(ctx context.Context, key Key) (crypto.Signer, error) {
 	pub, err := key.ExportPublic(ctx)
 	if err != nil {
 		return nil, err
 	}
 	return &signer{key: key, pub: pub, ctx: ctx}, nil
+}
+
+// NewSignerWithPublicKey is like [NewSigner] but does not export the public
+// key from the KMS and takes a pre-exported public key to use instead. This is
+// useful to skip re-exporting the public key when it was already exported and
+// stored before. While the caller cannot easily ensure that the public key and
+// underlying KMS private key match, APIs such as x509.CreateCeritificate will
+// assert this based on signatures that it creates.
+func NewSignerWithPublicKey(ctx context.Context, key Key, pub crypto.PublicKey) crypto.Signer {
+	return &signer{key: key, pub: pub, ctx: ctx}
 }
 
 type signer struct {


### PR DESCRIPTION
In PKI, we already store the exported public key in OpenBao's storage on issuer/key creation. The `kms.NewSigner` API however will re-fetch the public key unnecessarily. This adds an API that lets us use the package's existing signer type together with a public key that we provide ourselves.