### PR TITLE
Azure Key Vault Wrapper integration tests

### DIFF
--- a/.github/workflows/azure-integration-tests.yml
+++ b/.github/workflows/azure-integration-tests.yml
@@ -1,0 +1,42 @@
+name: Azure Key Vault integration tests
+description: Runs Azure Key Vault integration tests
+
+inputs:
+  tenant-id:
+    description: Azure tenant ID
+    required: true
+  client-id:
+    description: Azure client ID
+    required: true
+  client-secret:
+    description: Azure client secret
+    required: true
+  vault-name:
+    description: Azure Key Vault name
+    required: true
+  key-name:
+    description: Azure Key Vault key name
+    required: true
+  cert:
+    description: Azure client certificate (base64 encoded)
+    required: true
+  cert-password:
+    description: Azure client certificate password
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Azure Key Vault integration tests
+      working-directory: './wrappers/azurekeyvault'
+      env:
+        KMS_ACC_TESTS: 'true'
+        AZURE_CLIENT_SECRET: ${{ inputs.client-secret }}
+        AZURE_CLIENT_ID: ${{ inputs.client-id }}
+        AZUREKEYVAULT_CERT_CLIENT_CERT: ${{ inputs.cert }}
+        VAULT_AZUREKEYVAULT_CERTIFICATE_PASSWORD: ${{ inputs.cert-password }}
+        AZURE_TENANT_ID: ${{ inputs.tenant-id }}
+        AZUREKEYVAULT_WRAPPER_VAULT_NAME: ${{ inputs.vault-name }}
+        AZUREKEYVAULT_WRAPPER_KEY_NAME: ${{ inputs.key-name }}
+      run: go test ./...
+      shell: bash

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -57,6 +57,18 @@ jobs:
         working-directory: ${{ matrix.directory }}
         run: go test ./...
 
+      - name: Azure integration tests
+        if: matrix.directory == './wrappers/azurekeyvault'
+        uses: ./.github/actions/azure-integration-tests
+        with:
+          client-secret: ${{ secrets.AZUREKEYVAULT_CLIENT_SECRET_CLIENT_SECRET }}
+          client-id: ${{ secrets.AZUREKEYVAULT_CLIENT_SECRET_CLIENT_ID }}
+          cert: ${{ secrets.AZUREKEYVAULT_CERT_CLIENT_CERT }}
+          cert-password: ${{ secrets.AZUREKEYVAULT_CERT_CLIENT_KEY }}
+          tenant-id: ${{ secrets.AZUREKEYVAULT_TENANT_ID }}
+          vault-name: ${{ secrets.AZUREKEYVAULT_VAULT_NAME }}
+          key-name: ${{ secrets.AZUREKEYVAULT_KEY_NAME }}
+
       - name: Container tests
         if: steps.dockerfile.outputs.exists == 'true'
         run: docker build -f '${{ matrix.directory }}/Dockerfile' .

--- a/wrappers/azurekeyvault/azurekeyvault.go
+++ b/wrappers/azurekeyvault/azurekeyvault.go
@@ -69,15 +69,22 @@ const (
 // data (RSA keys). Due to this fact, we generate AES key and wrap the
 // key using Key Vault and store it with the data.
 type Wrapper struct {
-	tenantID      string
-	clientID      string
-	clientSecret  string
-	keyName       string
-	authMethod    authenticationMethod
-	vaultName     string
-	certPath      string
-	certBytes     string
-	certPassword  string
+	tenantID   string
+	vaultName  string
+	keyName    string
+	authMethod authenticationMethod
+
+	// Client secret authorization method properties.
+	clientID     string
+	clientSecret string
+
+	// Certificate auth method properties;
+	// CertPath is mutually exclusive with certBytes.
+	certPath     string
+	certBytes    string
+	certPassword string
+
+	// Managed identity authorization method properties.
 	resourceID    string
 	managedIdKind managedIdentityKind
 
@@ -526,7 +533,12 @@ func (v *Wrapper) getWorkloadIdentityCredential() (azcore.TokenCredential, error
 	if v.tenantID == "" {
 		return nil, errors.New("tenant_id is required for azure workload identity authentication")
 	}
-	cred, err := azidentity.NewWorkloadIdentityCredential(&azidentity.WorkloadIdentityCredentialOptions{TenantID: v.tenantID})
+
+	if v.clientID == "" {
+		return nil, errors.New("client_id is required for azure workload identity authentication")
+	}
+
+	cred, err := azidentity.NewWorkloadIdentityCredential(&azidentity.WorkloadIdentityCredentialOptions{TenantID: v.tenantID, ClientID: v.clientID})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get workload identity credentials: %w", err)
 	}

--- a/wrappers/azurekeyvault/azurekeyvault_acc_test.go
+++ b/wrappers/azurekeyvault/azurekeyvault_acc_test.go
@@ -4,184 +4,152 @@
 package azurekeyvault
 
 import (
+	"bytes"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"maps"
 	"math/big"
 	"os"
 	"testing"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
-
-	"github.com/Azure/go-autorest/autorest/azure"
 	wrapping "github.com/openbao/go-kms-wrapping/v2"
 	"github.com/stretchr/testify/require"
 )
 
-func TestAzureKeyVault_SetConfig(t *testing.T) {
-	s := NewWrapper()
-	os.Unsetenv("AZURE_TENANT_ID")
+func roundtrip(t *testing.T, ow *Wrapper) {
+	t.Helper()
 
-	// Attempt to set config, expect failure due to missing config
-	_, err := s.SetConfig(t.Context())
-	require.Error(t, err)
-
-	t.Setenv("AZURE_TENANT_ID", "tenant_id")
-	t.Setenv(EnvVaultAzureKeyVaultVaultName, "vault_name")
-	t.Setenv(EnvVaultAzureKeyVaultKeyName, "key_name")
-
-	_, err = s.SetConfig(t.Context(), wrapping.WithConfigMap(map[string]string{
-		"key_not_required": "true",
-	}))
+	input := []byte("foobar")
+	ciphertext0, err := ow.Encrypt(t.Context(), input)
 	require.NoError(t, err)
+	require.NotEqual(t, ciphertext0, input)
+
+	ciphertext1, err := ow.Encrypt(t.Context(), input)
+	require.NoError(t, err)
+	require.NotEqual(t, ciphertext1, input)
+	require.NotEqual(t, ciphertext1, ciphertext0)
+
+	plaintext0, err := ow.Decrypt(t.Context(), ciphertext0)
+	require.NoError(t, err)
+	require.Equal(t, input, plaintext0)
+
+	plaintext1, err := ow.Decrypt(t.Context(), ciphertext1)
+	require.NoError(t, err)
+	require.Equal(t, input, plaintext1)
+
+	corruptedCipher := &wrapping.BlobInfo{
+		Ciphertext: bytes.Clone(ciphertext0.Ciphertext),
+		Iv:         ciphertext0.Iv,
+		KeyInfo:    ciphertext0.KeyInfo,
+	}
+	corruptedCipher.Ciphertext[0] ^= 0xff
+	_, err = ow.Decrypt(t.Context(), corruptedCipher)
+	require.Error(t, err)
 }
 
-func TestMapAuthMethod(t *testing.T) {
+func TestAccWrapper(t *testing.T) {
+	if os.Getenv("VAULT_ACC") == "" && os.Getenv("KMS_ACC_TESTS") == "" {
+		t.SkipNow()
+	}
+
+	baseConfig := map[string]string{
+		"environment": "azurecloud",
+		"vault_name":  os.Getenv(EnvAzureKeyVaultWrapperVaultName),
+		"key_name":    os.Getenv(EnvAzureKeyVaultWrapperKeyName),
+	}
+
+	// Setup cert path.
+	tempDir := t.TempDir()
+	clientCertFile, err := os.CreateTemp(tempDir, "client-cert.pem")
+	require.NoError(t, err)
+	clientCert := os.Getenv("AZUREKEYVAULT_CERT_CLIENT_CERT")
+	_, err = clientCertFile.Write([]byte(clientCert))
+	clientCertFile.Close()
+	t.Setenv(EnvVaultAzureKeyVaultCertificatePath, clientCertFile.Name())
+
 	tests := []struct {
-		name     string
-		input    string
-		wrapper  *Wrapper
-		expected authenticationMethod
+		name           string
+		authMethod     string
+		config         map[string]string
+		disableEnvVars bool
 	}{
 		{
-			"Empty String",
-			"",
-			&Wrapper{},
-			DefaultAzureCredential,
+			name:       "client_secret without env vars",
+			authMethod: "client_secret",
+			config: map[string]string{
+				"tenant_id":     os.Getenv("AZURE_TENANT_ID"),
+				"client_id":     os.Getenv("AZURE_CLIENT_ID"),
+				"client_secret": os.Getenv("AZURE_CLIENT_SECRET"),
+			},
+			disableEnvVars: true,
 		},
 		{
-			"Managed Identity",
-			"managed_identity",
-			&Wrapper{},
-			ManagedIdentityCredential,
+			name:       "client_secret with env vars",
+			authMethod: "client_secret",
 		},
 		{
-			"Client Secret",
-			"client_secret",
-			&Wrapper{},
-			ClientSecretCredential,
+			name:       "certificate without env vars",
+			authMethod: "certificate",
+			config: map[string]string{
+				"tenant_id":     os.Getenv("AZUREKEYVAULT_TENANT_ID"),
+				"client_id":     os.Getenv("AZURE_CLIENT_ID"),
+				"cert_bytes":    os.Getenv("AZUREKEYVAULT_CERT_CLIENT_CERT"),
+				"cert_password": os.Getenv(EnvVaultAzureKeyVaultCertificatePassword),
+			},
+			disableEnvVars: true,
 		},
 		{
-			"Workload Identity",
-			"workload_identity",
-			&Wrapper{},
-			WorkloadIdentityCredential,
+			name:       "certificate with env vars",
+			authMethod: "certificate",
 		},
 		{
-			"Certificate",
-			"certificate",
-			&Wrapper{},
-			CertificateCredential,
+			name:       "environment",
+			authMethod: "environment",
 		},
 		{
-			"Environment",
-			"environment",
-			&Wrapper{},
-			EnvironmentCredential,
+			name:       "managed_identity without env vars",
+			authMethod: "managed_identity",
+			config: map[string]string{
+				"tenant_id":       os.Getenv("AZUREKEYVAULT_TENANT_ID"),
+				"client_id":       os.Getenv("AZURE_CLIENT_ID"),
+				"client_secret":   os.Getenv("AZURE_CLIENT_SECRET"),
+				"managed_id_kind": "CLIENT_ID",
+			},
+			disableEnvVars: true,
 		},
 		{
-			"Default",
-			"default",
-			&Wrapper{},
-			DefaultAzureCredential,
+			// TODO: managed_id_kind
+			name:       "managed_identity with env vars",
+			authMethod: "managed_identity",
 		},
-		{
-			"Invalid Input",
-			"invalid_input",
-			&Wrapper{},
-			DefaultAzureCredential,
-		},
-		{
-			"Mixed Case Input",
-			"Managed_Identity",
-			&Wrapper{},
-			ManagedIdentityCredential,
-		},
-		{
-			"Leading/Tailing Whitespace",
-			" client_secret ",
-			&Wrapper{},
-			DefaultAzureCredential,
-		},
-		{
-			"No specification with wrapper properties set to client_secret",
-			"",
-			&Wrapper{tenantID: "tenant", clientID: "client", clientSecret: "secret"},
-			ClientSecretCredential,
-		},
-		{
-			"No specification with wrapper properties set to certificate",
-			"",
-			&Wrapper{certPath: "./somepath/cert.pem"},
-			CertificateCredential,
-		},
-		{
-			"No specification with wrapper properties set to managed identity",
-			"",
-			&Wrapper{clientID: "client"},
-			ManagedIdentityCredential,
-		},
+		// needs AZURE_FEDERATED_TOKEN_FILE env
+		// {
+		// 	name:       "workload_identity with env vars",
+		// 	authMethod: "workload_identity",
+		// },
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.wrapper.configureAuthMethod(tt.input)
-			require.Equal(t, tt.expected, tt.wrapper.authMethod)
+			configMap := make(map[string]string, len(baseConfig)+len(tt.config))
+			maps.Copy(configMap, baseConfig)
+			maps.Copy(configMap, tt.config)
+			configMap["auth_method"] = tt.authMethod
+			configMap["key_not_required"] = "false"
+
+			s := NewWrapper()
+			opts := []wrapping.Option{wrapping.WithConfigMap(configMap), wrapping.WithDisallowEnvVars(tt.disableEnvVars)}
+
+			_, err := s.SetConfig(t.Context(), opts...)
+			require.NoError(t, err)
+
+			roundtrip(t, s)
 		})
 	}
-}
-
-func TestAzureKeyVault_IgnoreEnv(t *testing.T) {
-	config := map[string]string{
-		"tenant_id":        "a-tenant-id",
-		"client_id":        "a-client-id",
-		"client_secret":    "a-client-secret",
-		"environment":      azure.PublicCloud.Name,
-		"resource":         "a-resource",
-		"vault_name":       "a-vault-name",
-		"key_name":         "a-key-name",
-		"auth_method":      "client_secret",
-		"cert_path":        "/cert/someCert.pem",
-		"cert_password":    "somePassword",
-		"key_not_required": "true",
-	}
-	s := NewWrapper()
-	_, err := s.SetConfig(t.Context(),
-		wrapping.WithConfigMap(config),
-		wrapping.WithDisallowEnvVars(true))
-	require.NoError(t, err)
-	require.Equal(t, config["tenant_id"], s.tenantID)
-	require.Equal(t, config["client_id"], s.clientID)
-	require.Equal(t, config["client_secret"], s.clientSecret)
-	require.Equal(t, config["environment"], s.environment.Name)
-	require.Equal(t, "https://"+config["resource"]+"/", s.resource)
-	require.Equal(t, config["vault_name"], s.vaultName)
-	require.Equal(t, config["key_name"], s.keyName)
-	require.Equal(t, config["cert_path"], s.certPath)
-	require.Equal(t, config["cert_password"], s.certPassword)
-	require.Equal(t, ClientSecretCredential, s.authMethod)
-}
-
-func TestAzureKeyVault_Lifecycle(t *testing.T) {
-	if os.Getenv("VAULT_ACC") == "" {
-		t.SkipNow()
-	}
-
-	s := NewWrapper()
-	_, err := s.SetConfig(t.Context())
-	require.NoError(t, err)
-
-	// Test Encrypt and Decrypt calls
-	input := []byte("foo")
-	swi, err := s.Encrypt(t.Context(), input, nil)
-	require.NoError(t, err)
-
-	pt, err := s.Decrypt(t.Context(), swi, nil)
-	require.NoError(t, err)
-	require.Equal(t, input, pt)
 }
 
 func TestWrapper_getCredential_CertificateCredential(t *testing.T) {
@@ -232,113 +200,4 @@ func TestWrapper_getCredential_CertificateCredential(t *testing.T) {
 	cred, err := v.getCredential()
 	require.NoError(t, err)
 	require.NotNil(t, cred)
-}
-
-func TestCreds_getCertificate(t *testing.T) {
-	if os.Getenv("VAULT_ACC") == "" {
-		t.SkipNow()
-	}
-	ctx := t.Context()
-
-	clientID := os.Getenv("TEST_AZURE_CLIENT_ID")
-	tenantID := os.Getenv("TEST_AZURE_TENANT_ID")
-	vaultName := os.Getenv("TEST_VAULT_NAME")
-	keyName := os.Getenv("TEST_KEY_NAME")
-	plaintextInput := []byte("foo")
-	expectedOutput := "foo"
-
-	config := map[string]string{
-		"environment": azure.PublicCloud.Name,
-		"resource":    "vault.azure.net",
-		"vault_name":  vaultName,
-		"key_name":    keyName,
-		"auth_method": "certificate",
-		"cert_path":   "test-data/azure-app.crt",
-		"client_id":   clientID,
-		"tenant_id":   tenantID,
-	}
-
-	wrapper := NewWrapper()
-
-	setConfig := func() {
-		t.Helper()
-		t.Log("--- SetConfig ---")
-		_, err := wrapper.SetConfig(ctx,
-			wrapping.WithConfigMap(config),
-			wrapping.WithDisallowEnvVars(true))
-		require.NoError(t, err)
-	}
-
-	encrypt := func(data []byte) *wrapping.BlobInfo {
-		t.Helper()
-		t.Log("--- Encrypt ---")
-		blobInfo, err := wrapper.Encrypt(ctx, data)
-		require.NoError(t, err)
-		return blobInfo
-	}
-
-	decrypt := func(blobInfo *wrapping.BlobInfo) []byte {
-		t.Helper()
-		t.Log("--- Decrypt ---")
-		plaintext, err := wrapper.Decrypt(ctx, blobInfo)
-		require.NoError(t, err)
-		return plaintext
-	}
-
-	setConfig()
-	blobInfo := encrypt(plaintextInput)
-	plaintext := decrypt(blobInfo)
-	t.Log(string(plaintext))
-
-	require.Equal(t, expectedOutput, string(plaintext))
-}
-
-func TestWrapper_getManagedIdentityID(t *testing.T) {
-	tests := []struct {
-		name           string
-		managedIdKind  managedIdentityKind
-		clientID       string
-		resourceID     string
-		expectedResult azidentity.ManagedIDKind
-	}{
-		{
-			name:           "ClientID case",
-			managedIdKind:  clientId,
-			clientID:       "test-client-id",
-			resourceID:     "test-resource-id",
-			expectedResult: azidentity.ClientID("test-client-id"),
-		},
-		{
-			name:           "ResourceID case",
-			managedIdKind:  resourceId,
-			clientID:       "test-client-id",
-			resourceID:     "test-resource-id",
-			expectedResult: azidentity.ResourceID("test-resource-id"),
-		},
-		{
-			name:           "Undefined managed ID kind case with ClientID",
-			managedIdKind:  undefined,
-			clientID:       "fallback-client-id",
-			resourceID:     "ignored-resource-id",
-			expectedResult: azidentity.ClientID("fallback-client-id"),
-		},
-		{
-			name:           "Default case with unknown managed ID kind",
-			managedIdKind:  99, // Unknown value
-			clientID:       "test-client-id",
-			resourceID:     "test-resource-id",
-			expectedResult: nil,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			wrapper := &Wrapper{
-				clientID:      tc.clientID,
-				resourceID:    tc.resourceID,
-				managedIdKind: tc.managedIdKind,
-			}
-			require.Equal(t, tc.expectedResult, wrapper.getManagedIdentityID())
-		})
-	}
 }

--- a/wrappers/azurekeyvault/azurekeyvault_test.go
+++ b/wrappers/azurekeyvault/azurekeyvault_test.go
@@ -1,0 +1,209 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package azurekeyvault
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+
+	"github.com/Azure/go-autorest/autorest/azure"
+	wrapping "github.com/openbao/go-kms-wrapping/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAzureKeyVault_SetConfig(t *testing.T) {
+	s := NewWrapper()
+	os.Unsetenv("AZURE_TENANT_ID")
+
+	// Attempt to set config, expect failure due to missing config
+	_, err := s.SetConfig(t.Context())
+	require.Error(t, err)
+
+	t.Setenv("AZURE_TENANT_ID", "tenant_id")
+	t.Setenv(EnvVaultAzureKeyVaultVaultName, "vault_name")
+	t.Setenv(EnvVaultAzureKeyVaultKeyName, "key_name")
+
+	_, err = s.SetConfig(t.Context(), wrapping.WithConfigMap(map[string]string{
+		"key_not_required": "true",
+	}))
+	require.NoError(t, err)
+}
+
+func TestMapAuthMethod(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wrapper  *Wrapper
+		expected authenticationMethod
+	}{
+		{
+			"Empty String",
+			"",
+			&Wrapper{},
+			DefaultAzureCredential,
+		},
+		{
+			"Managed Identity",
+			"managed_identity",
+			&Wrapper{},
+			ManagedIdentityCredential,
+		},
+		{
+			"Client Secret",
+			"client_secret",
+			&Wrapper{},
+			ClientSecretCredential,
+		},
+		{
+			"Workload Identity",
+			"workload_identity",
+			&Wrapper{},
+			WorkloadIdentityCredential,
+		},
+		{
+			"Certificate",
+			"certificate",
+			&Wrapper{},
+			CertificateCredential,
+		},
+		{
+			"Environment",
+			"environment",
+			&Wrapper{},
+			EnvironmentCredential,
+		},
+		{
+			"Default",
+			"default",
+			&Wrapper{},
+			DefaultAzureCredential,
+		},
+		{
+			"Invalid Input",
+			"invalid_input",
+			&Wrapper{},
+			DefaultAzureCredential,
+		},
+		{
+			"Mixed Case Input",
+			"Managed_Identity",
+			&Wrapper{},
+			ManagedIdentityCredential,
+		},
+		{
+			"Leading/Tailing Whitespace",
+			" client_secret ",
+			&Wrapper{},
+			DefaultAzureCredential,
+		},
+		{
+			"No specification with wrapper properties set to client_secret",
+			"",
+			&Wrapper{tenantID: "tenant", clientID: "client", clientSecret: "secret"},
+			ClientSecretCredential,
+		},
+		{
+			"No specification with wrapper properties set to certificate",
+			"",
+			&Wrapper{certPath: "./somepath/cert.pem"},
+			CertificateCredential,
+		},
+		{
+			"No specification with wrapper properties set to managed identity",
+			"",
+			&Wrapper{clientID: "client"},
+			ManagedIdentityCredential,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.wrapper.configureAuthMethod(tt.input)
+			require.Equal(t, tt.expected, tt.wrapper.authMethod)
+		})
+	}
+}
+
+func TestAzureKeyVault_IgnoreEnv(t *testing.T) {
+	config := map[string]string{
+		"tenant_id":        "a-tenant-id",
+		"client_id":        "a-client-id",
+		"client_secret":    "a-client-secret",
+		"environment":      azure.PublicCloud.Name,
+		"resource":         "a-resource",
+		"vault_name":       "a-vault-name",
+		"key_name":         "a-key-name",
+		"auth_method":      "client_secret",
+		"cert_path":        "/cert/someCert.pem",
+		"cert_password":    "somePassword",
+		"key_not_required": "true",
+	}
+	s := NewWrapper()
+	_, err := s.SetConfig(t.Context(),
+		wrapping.WithConfigMap(config),
+		wrapping.WithDisallowEnvVars(true))
+	require.NoError(t, err)
+	require.Equal(t, config["tenant_id"], s.tenantID)
+	require.Equal(t, config["client_id"], s.clientID)
+	require.Equal(t, config["client_secret"], s.clientSecret)
+	require.Equal(t, config["environment"], s.environment.Name)
+	require.Equal(t, "https://"+config["resource"]+"/", s.resource)
+	require.Equal(t, config["vault_name"], s.vaultName)
+	require.Equal(t, config["key_name"], s.keyName)
+	require.Equal(t, config["cert_path"], s.certPath)
+	require.Equal(t, config["cert_password"], s.certPassword)
+	require.Equal(t, ClientSecretCredential, s.authMethod)
+}
+
+func TestWrapper_getManagedIdentityID(t *testing.T) {
+	tests := []struct {
+		name           string
+		managedIdKind  managedIdentityKind
+		clientID       string
+		resourceID     string
+		expectedResult azidentity.ManagedIDKind
+	}{
+		{
+			name:           "ClientID case",
+			managedIdKind:  clientId,
+			clientID:       "test-client-id",
+			resourceID:     "test-resource-id",
+			expectedResult: azidentity.ClientID("test-client-id"),
+		},
+		{
+			name:           "ResourceID case",
+			managedIdKind:  resourceId,
+			clientID:       "test-client-id",
+			resourceID:     "test-resource-id",
+			expectedResult: azidentity.ResourceID("test-resource-id"),
+		},
+		{
+			name:           "Undefined managed ID kind case with ClientID",
+			managedIdKind:  undefined,
+			clientID:       "fallback-client-id",
+			resourceID:     "ignored-resource-id",
+			expectedResult: azidentity.ClientID("fallback-client-id"),
+		},
+		{
+			name:           "Default case with unknown managed ID kind",
+			managedIdKind:  99, // Unknown value
+			clientID:       "test-client-id",
+			resourceID:     "test-resource-id",
+			expectedResult: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			wrapper := &Wrapper{
+				clientID:      tc.clientID,
+				resourceID:    tc.resourceID,
+				managedIdKind: tc.managedIdKind,
+			}
+			require.Equal(t, tc.expectedResult, wrapper.getManagedIdentityID())
+		})
+	}
+}


### PR DESCRIPTION
This PR adds integration tests for the Azure Key Vault wrapper using real provider keys to test encrypt/decrypt functionality.

requires #150 as a testing trigger method